### PR TITLE
✨ Add 68 CNCF project entries with help-wanted program

### DIFF
--- a/presets/cncf-argo.json
+++ b/presets/cncf-argo.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "argocd_applications",
+  "title": "Argo CD Applications",
+  "config": {}
+}

--- a/presets/cncf-artifact-hub.json
+++ b/presets/cncf-artifact-hub.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "artifact-hub_status",
+  "title": "Artifact Hub",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-backstage.json
+++ b/presets/cncf-backstage.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "backstage_status",
+  "title": "Backstage",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-buildpacks.json
+++ b/presets/cncf-buildpacks.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "buildpacks_status",
+  "title": "Cloud Native Buildpacks",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cert-manager.json
+++ b/presets/cncf-cert-manager.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cert_manager",
+  "title": "cert-manager Certificates",
+  "config": {}
+}

--- a/presets/cncf-chaos-mesh.json
+++ b/presets/cncf-chaos-mesh.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "chaos-mesh_status",
+  "title": "Chaos Mesh",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cilium.json
+++ b/presets/cncf-cilium.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cilium_status",
+  "title": "Cilium",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cloud-custodian.json
+++ b/presets/cncf-cloud-custodian.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cloud-custodian_status",
+  "title": "Cloud Custodian",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cloudevents.json
+++ b/presets/cncf-cloudevents.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cloudevents_status",
+  "title": "CloudEvents",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cni.json
+++ b/presets/cncf-cni.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cni_status",
+  "title": "CNI",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-containerd.json
+++ b/presets/cncf-containerd.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "containerd_status",
+  "title": "containerd",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-contour.json
+++ b/presets/cncf-contour.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "contour_status",
+  "title": "Contour",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-coredns.json
+++ b/presets/cncf-coredns.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "coredns_status",
+  "title": "CoreDNS",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cortex.json
+++ b/presets/cncf-cortex.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cortex_status",
+  "title": "Cortex",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-crio.json
+++ b/presets/cncf-crio.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "crio_status",
+  "title": "CRI-O",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-crossplane.json
+++ b/presets/cncf-crossplane.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "crossplane_status",
+  "title": "Crossplane",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-cubefs.json
+++ b/presets/cncf-cubefs.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cubefs_status",
+  "title": "CubeFS",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-dapr.json
+++ b/presets/cncf-dapr.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "dapr_status",
+  "title": "Dapr",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-dragonfly.json
+++ b/presets/cncf-dragonfly.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "dragonfly_status",
+  "title": "Dragonfly",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-envoy.json
+++ b/presets/cncf-envoy.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "envoy_status",
+  "title": "Envoy Proxy",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-etcd.json
+++ b/presets/cncf-etcd.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "etcd_status",
+  "title": "etcd",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-falco.json
+++ b/presets/cncf-falco.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "falco_alerts",
+  "title": "Falco Runtime Alerts",
+  "config": {}
+}

--- a/presets/cncf-flatcar.json
+++ b/presets/cncf-flatcar.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "flatcar_status",
+  "title": "Flatcar Container Linux",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-fluentd.json
+++ b/presets/cncf-fluentd.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "fluentd_status",
+  "title": "Fluentd",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-fluid.json
+++ b/presets/cncf-fluid.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "fluid_status",
+  "title": "Fluid",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-flux.json
+++ b/presets/cncf-flux.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "flux_status",
+  "title": "Flux CD",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-grpc.json
+++ b/presets/cncf-grpc.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "grpc_status",
+  "title": "gRPC",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-harbor.json
+++ b/presets/cncf-harbor.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "harbor_status",
+  "title": "Harbor Registry",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-helm.json
+++ b/presets/cncf-helm.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "helm_release_status",
+  "title": "Helm Release Status",
+  "config": {}
+}

--- a/presets/cncf-in-toto.json
+++ b/presets/cncf-in-toto.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "in-toto_status",
+  "title": "in-toto",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-istio.json
+++ b/presets/cncf-istio.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "service_topology",
+  "title": "Istio Service Mesh",
+  "config": {}
+}

--- a/presets/cncf-jaeger.json
+++ b/presets/cncf-jaeger.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "jaeger_status",
+  "title": "Jaeger Tracing",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-karmada.json
+++ b/presets/cncf-karmada.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "karmada_status",
+  "title": "Karmada",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-keda.json
+++ b/presets/cncf-keda.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "keda_status",
+  "title": "KEDA",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-keycloak.json
+++ b/presets/cncf-keycloak.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "keycloak_status",
+  "title": "Keycloak",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-knative.json
+++ b/presets/cncf-knative.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "knative_status",
+  "title": "Knative",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-kserve.json
+++ b/presets/cncf-kserve.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kserve_status",
+  "title": "KServe",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-kubeflow.json
+++ b/presets/cncf-kubeflow.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kubeflow_status",
+  "title": "Kubeflow",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-kubernetes.json
+++ b/presets/cncf-kubernetes.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "cluster_health",
+  "title": "Kubernetes Cluster Health",
+  "config": {}
+}

--- a/presets/cncf-kubescape.json
+++ b/presets/cncf-kubescape.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kubescape_scan",
+  "title": "Kubescape Security Scan",
+  "config": {}
+}

--- a/presets/cncf-kubevela.json
+++ b/presets/cncf-kubevela.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kubevela_status",
+  "title": "KubeVela",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-kubevirt.json
+++ b/presets/cncf-kubevirt.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kubevirt_status",
+  "title": "KubeVirt",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-kyverno.json
+++ b/presets/cncf-kyverno.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "kyverno_policies",
+  "title": "Kyverno Policies",
+  "config": {}
+}

--- a/presets/cncf-lima.json
+++ b/presets/cncf-lima.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "lima_status",
+  "title": "Lima",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-linkerd.json
+++ b/presets/cncf-linkerd.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "linkerd_status",
+  "title": "Linkerd",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-longhorn.json
+++ b/presets/cncf-longhorn.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "longhorn_status",
+  "title": "Longhorn",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-metal3.json
+++ b/presets/cncf-metal3.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "metal3_status",
+  "title": "Metal3",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-nats.json
+++ b/presets/cncf-nats.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "nats_status",
+  "title": "NATS",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-notary.json
+++ b/presets/cncf-notary.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "notary_status",
+  "title": "Notary",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-opa.json
+++ b/presets/cncf-opa.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "opa_policies",
+  "title": "OPA Gatekeeper Policies",
+  "config": {}
+}

--- a/presets/cncf-opencost.json
+++ b/presets/cncf-opencost.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "opencost_overview",
+  "title": "OpenCost Overview",
+  "config": {}
+}

--- a/presets/cncf-openfeature.json
+++ b/presets/cncf-openfeature.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "openfeature_status",
+  "title": "OpenFeature",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-openfga.json
+++ b/presets/cncf-openfga.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "openfga_status",
+  "title": "OpenFGA",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-openkruise.json
+++ b/presets/cncf-openkruise.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "openkruise_status",
+  "title": "OpenKruise",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-opentelemetry.json
+++ b/presets/cncf-opentelemetry.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "opentelemetry_status",
+  "title": "OpenTelemetry",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-openyurt.json
+++ b/presets/cncf-openyurt.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "openyurt_status",
+  "title": "OpenYurt",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-operator-framework.json
+++ b/presets/cncf-operator-framework.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "operator-framework_status",
+  "title": "Operator Framework",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-prometheus.json
+++ b/presets/cncf-prometheus.json
@@ -1,0 +1,6 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "active_alerts",
+  "title": "Prometheus Alerts",
+  "config": {}
+}

--- a/presets/cncf-rook.json
+++ b/presets/cncf-rook.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "rook_status",
+  "title": "Rook Storage",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-spiffe.json
+++ b/presets/cncf-spiffe.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "spiffe_status",
+  "title": "SPIFFE",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-spire.json
+++ b/presets/cncf-spire.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "spire_status",
+  "title": "SPIRE",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-strimzi.json
+++ b/presets/cncf-strimzi.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "strimzi_status",
+  "title": "Strimzi",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-thanos.json
+++ b/presets/cncf-thanos.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "thanos_status",
+  "title": "Thanos",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-tikv.json
+++ b/presets/cncf-tikv.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "tikv_status",
+  "title": "TiKV",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-tuf.json
+++ b/presets/cncf-tuf.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "tuf_status",
+  "title": "TUF",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-vitess.json
+++ b/presets/cncf-vitess.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "vitess_status",
+  "title": "Vitess",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-volcano.json
+++ b/presets/cncf-volcano.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "volcano_status",
+  "title": "Volcano",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/presets/cncf-wasmcloud.json
+++ b/presets/cncf-wasmcloud.json
@@ -1,0 +1,8 @@
+{
+  "format": "kc-card-preset-v1",
+  "card_type": "wasmcloud_status",
+  "title": "wasmCloud",
+  "config": {},
+  "_placeholder": true,
+  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+}

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.0",
-  "updatedAt": "2026-02-10T00:00:00Z",
+  "version": "2.0.0",
+  "updatedAt": "2026-02-11T00:00:00Z",
   "items": [
     {
       "id": "sre-overview",
@@ -9,7 +9,11 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/dashboards/sre-overview/dashboard.json",
-      "tags": ["sre", "monitoring", "production"],
+      "tags": [
+        "sre",
+        "monitoring",
+        "production"
+      ],
       "cardCount": 6,
       "type": "dashboard"
     },
@@ -20,7 +24,11 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/dashboards/security-audit/dashboard.json",
-      "tags": ["security", "compliance", "rbac"],
+      "tags": [
+        "security",
+        "compliance",
+        "rbac"
+      ],
       "cardCount": 5,
       "type": "dashboard"
     },
@@ -31,7 +39,12 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/dashboards/gitops-pipeline/dashboard.json",
-      "tags": ["gitops", "helm", "argocd", "deployments"],
+      "tags": [
+        "gitops",
+        "helm",
+        "argocd",
+        "deployments"
+      ],
       "cardCount": 5,
       "type": "dashboard"
     },
@@ -42,7 +55,11 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/card-presets/pod-health-monitor.json",
-      "tags": ["monitoring", "pods", "health"],
+      "tags": [
+        "monitoring",
+        "pods",
+        "health"
+      ],
       "cardCount": 1,
       "type": "card-preset"
     },
@@ -53,7 +70,11 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/card-presets/warning-event-stream.json",
-      "tags": ["events", "monitoring", "alerts"],
+      "tags": [
+        "events",
+        "monitoring",
+        "alerts"
+      ],
       "cardCount": 1,
       "type": "card-preset"
     },
@@ -64,7 +85,11 @@
       "author": "kubestellar",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/card-presets/cluster-overview.json",
-      "tags": ["clusters", "overview", "health"],
+      "tags": [
+        "clusters",
+        "overview",
+        "health"
+      ],
       "cardCount": 1,
       "type": "card-preset"
     },
@@ -75,10 +100,20 @@
       "author": "community",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/themes/midnight-blue.json",
-      "tags": ["dark", "blue", "minimal"],
+      "tags": [
+        "dark",
+        "blue",
+        "minimal"
+      ],
       "cardCount": 0,
       "type": "theme",
-      "themeColors": ["#0891b2", "#3b82f6", "#6366f1", "#10b981", "#06b6d4"]
+      "themeColors": [
+        "#0891b2",
+        "#3b82f6",
+        "#6366f1",
+        "#10b981",
+        "#06b6d4"
+      ]
     },
     {
       "id": "amber-glow",
@@ -87,10 +122,1904 @@
       "author": "community",
       "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/themes/amber-glow.json",
-      "tags": ["dark", "warm", "amber"],
+      "tags": [
+        "dark",
+        "warm",
+        "amber"
+      ],
       "cardCount": 0,
       "type": "theme",
-      "themeColors": ["#f59e0b", "#f97316", "#ef4444", "#10b981", "#06b6d4"]
+      "themeColors": [
+        "#f59e0b",
+        "#f97316",
+        "#ef4444",
+        "#10b981",
+        "#06b6d4"
+      ]
+    },
+    {
+      "id": "cncf-kubernetes",
+      "name": "Kubernetes Cluster Health",
+      "description": "Monitor Kubernetes cluster health, node status, and resource utilization across your fleet.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kubernetes.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "orchestration",
+        "monitoring"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Orchestration",
+        "website": "https://kubernetes.io"
+      }
+    },
+    {
+      "id": "cncf-helm",
+      "name": "Helm Release Status",
+      "description": "Track Helm chart releases, versions, and deployment status across all clusters.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-helm.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "helm",
+        "deployments"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "App Definition",
+        "website": "https://helm.sh"
+      }
+    },
+    {
+      "id": "cncf-argo",
+      "name": "Argo CD Applications",
+      "description": "Monitor ArgoCD application sync status, health, and GitOps workflow across clusters.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-argo.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "gitops",
+        "argocd"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "App Definition",
+        "website": "https://argoproj.github.io/cd"
+      }
+    },
+    {
+      "id": "cncf-prometheus",
+      "name": "Prometheus Alerts",
+      "description": "Active alerts and firing rules from Prometheus AlertManager across clusters.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-prometheus.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "observability",
+        "monitoring"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Observability",
+        "website": "https://prometheus.io"
+      }
+    },
+    {
+      "id": "cncf-opa",
+      "name": "OPA Gatekeeper Policies",
+      "description": "OPA Gatekeeper policy violations, constraint templates, and compliance status.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-opa.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "policies"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://www.openpolicyagent.org"
+      }
+    },
+    {
+      "id": "cncf-falco",
+      "name": "Falco Runtime Alerts",
+      "description": "Runtime security alerts from Falco detecting suspicious behavior in containers.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-falco.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "runtime"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://falco.org"
+      }
+    },
+    {
+      "id": "cncf-cert-manager",
+      "name": "cert-manager Certificates",
+      "description": "TLS certificate status, expiry tracking, and issuer health from cert-manager.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cert-manager.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "certificates"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://cert-manager.io"
+      }
+    },
+    {
+      "id": "cncf-istio",
+      "name": "Istio Service Mesh",
+      "description": "Istio service mesh topology, traffic routing, and sidecar injection status.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-istio.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "service-mesh",
+        "networking"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Service Mesh",
+        "website": "https://istio.io"
+      }
+    },
+    {
+      "id": "cncf-kyverno",
+      "name": "Kyverno Policies",
+      "description": "Kyverno policy reports, violations, and admission control status.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kyverno.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "policies"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://kyverno.io"
+      }
+    },
+    {
+      "id": "cncf-kubescape",
+      "name": "Kubescape Security Scan",
+      "description": "Kubescape security scan results, framework compliance, and risk assessment.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kubescape.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "compliance"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://kubescape.io"
+      }
+    },
+    {
+      "id": "cncf-opencost",
+      "name": "OpenCost Overview",
+      "description": "Kubernetes cost monitoring with per-namespace and per-workload cost breakdown.",
+      "author": "kubestellar",
+      "version": "1.0.0",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-opencost.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "observability",
+        "cost"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "available",
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Observability",
+        "website": "https://opencost.io"
+      }
+    },
+    {
+      "id": "cncf-envoy",
+      "name": "Envoy Proxy",
+      "description": "Monitor Envoy proxy configurations, listeners, clusters, and traffic routing across your service mesh.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-envoy.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "service-mesh",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Envoy Admin API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Service Mesh",
+        "website": "https://www.envoyproxy.io"
+      }
+    },
+    {
+      "id": "cncf-containerd",
+      "name": "containerd",
+      "description": "Container runtime status, image management, and namespace utilization from containerd.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-containerd.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "containerd API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Runtime",
+        "website": "https://containerd.io"
+      }
+    },
+    {
+      "id": "cncf-coredns",
+      "name": "CoreDNS",
+      "description": "DNS query metrics, cache hit rates, and resolution performance from CoreDNS.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-coredns.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "DNS Metrics"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Orchestration",
+        "website": "https://coredns.io"
+      }
+    },
+    {
+      "id": "cncf-etcd",
+      "name": "etcd",
+      "description": "etcd cluster health, leader status, key-value store metrics, and WAL performance.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-etcd.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "etcd API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Orchestration",
+        "website": "https://etcd.io"
+      }
+    },
+    {
+      "id": "cncf-fluentd",
+      "name": "Fluentd",
+      "description": "Log pipeline status, buffer utilization, and output plugin health from Fluentd.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-fluentd.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "observability",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Fluentd API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Observability",
+        "website": "https://www.fluentd.org"
+      }
+    },
+    {
+      "id": "cncf-grpc",
+      "name": "gRPC",
+      "description": "gRPC service health, call metrics, and error rates from gRPC reflection endpoints.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-grpc.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "gRPC Reflection"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "App Definition",
+        "website": "https://grpc.io"
+      }
+    },
+    {
+      "id": "cncf-jaeger",
+      "name": "Jaeger Tracing",
+      "description": "Distributed trace collection, service dependencies, and latency analysis from Jaeger.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-jaeger.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "observability",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Jaeger API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Observability",
+        "website": "https://www.jaegertracing.io"
+      }
+    },
+    {
+      "id": "cncf-linkerd",
+      "name": "Linkerd",
+      "description": "Linkerd service mesh metrics, mTLS status, and proxy health across workloads.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-linkerd.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "service-mesh",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Linkerd API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Service Mesh",
+        "website": "https://linkerd.io"
+      }
+    },
+    {
+      "id": "cncf-crio",
+      "name": "CRI-O",
+      "description": "CRI-O container runtime metrics, image pulls, and pod sandbox status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-crio.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "CRI-O API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Runtime",
+        "website": "https://cri-o.io"
+      }
+    },
+    {
+      "id": "cncf-tikv",
+      "name": "TiKV",
+      "description": "TiKV distributed key-value store metrics, region status, and storage utilization.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-tikv.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "TiKV API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Storage",
+        "website": "https://tikv.org"
+      }
+    },
+    {
+      "id": "cncf-vitess",
+      "name": "Vitess",
+      "description": "Vitess database clustering status, tablet health, and query performance via VTAdmin.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-vitess.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "VTAdmin API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Storage",
+        "website": "https://vitess.io"
+      }
+    },
+    {
+      "id": "cncf-cloudevents",
+      "name": "CloudEvents",
+      "description": "CloudEvents message flow, event source tracking, and delivery status monitoring.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cloudevents.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "serverless",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Serverless",
+        "website": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "cncf-tuf",
+      "name": "TUF",
+      "description": "The Update Framework metadata status, signature verification, and repository health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-tuf.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://theupdateframework.io"
+      }
+    },
+    {
+      "id": "cncf-harbor",
+      "name": "Harbor Registry",
+      "description": "Harbor container registry projects, repositories, vulnerability scan results, and replication status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-harbor.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "provisioning",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Harbor API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Provisioning",
+        "website": "https://goharbor.io"
+      }
+    },
+    {
+      "id": "cncf-rook",
+      "name": "Rook Storage",
+      "description": "Rook-Ceph cluster health, OSD status, pool utilization, and storage capacity.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-rook.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Ceph API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Storage",
+        "website": "https://rook.io"
+      }
+    },
+    {
+      "id": "cncf-spiffe",
+      "name": "SPIFFE",
+      "description": "SPIFFE identity federation, trust domain status, and workload identity management.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-spiffe.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "SPIRE API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://spiffe.io"
+      }
+    },
+    {
+      "id": "cncf-spire",
+      "name": "SPIRE",
+      "description": "SPIRE server health, agent registration, and workload attestation status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-spire.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "SPIRE API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://spiffe.io/spire"
+      }
+    },
+    {
+      "id": "cncf-cubefs",
+      "name": "CubeFS",
+      "description": "CubeFS distributed file system health, volume status, and metadata server metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cubefs.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "CubeFS API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Storage",
+        "website": "https://cubefs.io"
+      }
+    },
+    {
+      "id": "cncf-dapr",
+      "name": "Dapr",
+      "description": "Dapr sidecar status, component health, and distributed application building block metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-dapr.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Dapr API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Runtime",
+        "website": "https://dapr.io"
+      }
+    },
+    {
+      "id": "cncf-dragonfly",
+      "name": "Dragonfly",
+      "description": "Dragonfly P2P image distribution, download progress, and seed peer status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-dragonfly.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "provisioning",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Provisioning",
+        "website": "https://d7y.io"
+      }
+    },
+    {
+      "id": "cncf-keda",
+      "name": "KEDA",
+      "description": "KEDA autoscaler status, scaled object metrics, and trigger queue depths.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-keda.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Orchestration",
+        "website": "https://keda.sh"
+      }
+    },
+    {
+      "id": "cncf-knative",
+      "name": "Knative",
+      "description": "Knative serving revisions, traffic routing, and eventing broker status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-knative.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "serverless",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Knative API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Serverless",
+        "website": "https://knative.dev"
+      }
+    },
+    {
+      "id": "cncf-cilium",
+      "name": "Cilium",
+      "description": "Cilium eBPF networking, network policy enforcement, and Hubble flow visibility.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cilium.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "networking",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Hubble API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Networking",
+        "website": "https://cilium.io"
+      }
+    },
+    {
+      "id": "cncf-crossplane",
+      "name": "Crossplane",
+      "description": "Crossplane managed resources, composite claims, and cloud provider status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-crossplane.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "provisioning",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Crossplane CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Provisioning",
+        "website": "https://crossplane.io"
+      }
+    },
+    {
+      "id": "cncf-flux",
+      "name": "Flux CD",
+      "description": "Flux GitOps sources, kustomizations, and Helm release reconciliation status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-flux.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Flux CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "App Definition",
+        "website": "https://fluxcd.io"
+      }
+    },
+    {
+      "id": "cncf-in-toto",
+      "name": "in-toto",
+      "description": "in-toto supply chain layout verification, step attestation, and link metadata status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-in-toto.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Security",
+        "website": "https://in-toto.io"
+      }
+    },
+    {
+      "id": "cncf-opentelemetry",
+      "name": "OpenTelemetry",
+      "description": "OpenTelemetry collector health, pipeline status, and telemetry data flow metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-opentelemetry.json",
+      "tags": [
+        "cncf",
+        "graduated",
+        "observability",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "OTLP API"
+      ],
+      "cncfProject": {
+        "maturity": "graduated",
+        "category": "Observability",
+        "website": "https://opentelemetry.io"
+      }
+    },
+    {
+      "id": "cncf-backstage",
+      "name": "Backstage",
+      "description": "Backstage developer portal catalog, component health, and plugin status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-backstage.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Backstage API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://backstage.io"
+      }
+    },
+    {
+      "id": "cncf-buildpacks",
+      "name": "Cloud Native Buildpacks",
+      "description": "Buildpack build status, builder health, and image build history.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-buildpacks.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://buildpacks.io"
+      }
+    },
+    {
+      "id": "cncf-cloud-custodian",
+      "name": "Cloud Custodian",
+      "description": "Cloud Custodian policy execution results, resource compliance, and remediation actions.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cloud-custodian.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://cloudcustodian.io"
+      }
+    },
+    {
+      "id": "cncf-cni",
+      "name": "CNI",
+      "description": "Container Network Interface plugin status, network allocation, and connectivity health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cni.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "networking",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "CNI API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Networking",
+        "website": "https://www.cni.dev"
+      }
+    },
+    {
+      "id": "cncf-contour",
+      "name": "Contour",
+      "description": "Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-contour.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "networking",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Networking",
+        "website": "https://projectcontour.io"
+      }
+    },
+    {
+      "id": "cncf-cortex",
+      "name": "Cortex",
+      "description": "Cortex multi-tenant metrics storage, ingester ring status, and query performance.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cortex.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "observability",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Cortex API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Observability",
+        "website": "https://cortexmetrics.io"
+      }
+    },
+    {
+      "id": "cncf-chaos-mesh",
+      "name": "Chaos Mesh",
+      "description": "Chaos Mesh experiment status, workflow progress, and chaos injection schedules.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-chaos-mesh.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://chaos-mesh.org"
+      }
+    },
+    {
+      "id": "cncf-fluid",
+      "name": "Fluid",
+      "description": "Fluid dataset caching status, runtime health, and data access acceleration metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-fluid.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Storage",
+        "website": "https://fluid-cloudnative.github.io"
+      }
+    },
+    {
+      "id": "cncf-kserve",
+      "name": "KServe",
+      "description": "KServe inference service status, model serving metrics, and autoscaling health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kserve.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://kserve.github.io/kserve"
+      }
+    },
+    {
+      "id": "cncf-karmada",
+      "name": "Karmada",
+      "description": "Karmada multi-cluster resource propagation, override policies, and member cluster status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-karmada.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Karmada API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Orchestration",
+        "website": "https://karmada.io"
+      }
+    },
+    {
+      "id": "cncf-keycloak",
+      "name": "Keycloak",
+      "description": "Keycloak realm status, user sessions, client configurations, and authentication flows.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-keycloak.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Keycloak API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://www.keycloak.org"
+      }
+    },
+    {
+      "id": "cncf-kubeflow",
+      "name": "Kubeflow",
+      "description": "Kubeflow pipeline runs, experiment tracking, and ML workflow status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kubeflow.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Kubeflow API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://www.kubeflow.org"
+      }
+    },
+    {
+      "id": "cncf-kubevirt",
+      "name": "KubeVirt",
+      "description": "KubeVirt virtual machine status, migration progress, and virtualization metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kubevirt.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "KubeVirt API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://kubevirt.io"
+      }
+    },
+    {
+      "id": "cncf-kubevela",
+      "name": "KubeVela",
+      "description": "KubeVela application status, component health, and OAM resource tracking.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kubevela.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://kubevela.io"
+      }
+    },
+    {
+      "id": "cncf-lima",
+      "name": "Lima",
+      "description": "Lima virtual machine instances, port forwarding status, and resource usage.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-lima.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://lima-vm.io"
+      }
+    },
+    {
+      "id": "cncf-longhorn",
+      "name": "Longhorn",
+      "description": "Longhorn distributed storage volumes, replica health, and backup status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-longhorn.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "storage",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Longhorn API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Storage",
+        "website": "https://longhorn.io"
+      }
+    },
+    {
+      "id": "cncf-metal3",
+      "name": "Metal3",
+      "description": "Metal3 bare metal host provisioning, BMC status, and machine health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-metal3.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "provisioning",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Metal3 API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Provisioning",
+        "website": "https://metal3.io"
+      }
+    },
+    {
+      "id": "cncf-nats",
+      "name": "NATS",
+      "description": "NATS messaging server status, JetStream streams, and consumer health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-nats.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "streaming",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "NATS API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Streaming",
+        "website": "https://nats.io"
+      }
+    },
+    {
+      "id": "cncf-notary",
+      "name": "Notary",
+      "description": "Notary container image signing status, trust policies, and signature verification.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-notary.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://notaryproject.dev"
+      }
+    },
+    {
+      "id": "cncf-openfeature",
+      "name": "OpenFeature",
+      "description": "OpenFeature flag evaluation status, provider health, and feature flag configurations.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-openfeature.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://openfeature.dev"
+      }
+    },
+    {
+      "id": "cncf-openfga",
+      "name": "OpenFGA",
+      "description": "OpenFGA authorization model status, relationship tuples, and access check metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-openfga.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "security",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "OpenFGA API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Security",
+        "website": "https://openfga.dev"
+      }
+    },
+    {
+      "id": "cncf-openkruise",
+      "name": "OpenKruise",
+      "description": "OpenKruise advanced workload status, sidecar injection, and image pre-pulling progress.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-openkruise.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Orchestration",
+        "website": "https://openkruise.io"
+      }
+    },
+    {
+      "id": "cncf-openyurt",
+      "name": "OpenYurt",
+      "description": "OpenYurt edge node pools, autonomy status, and edge-cloud connectivity.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-openyurt.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Orchestration",
+        "website": "https://openyurt.io"
+      }
+    },
+    {
+      "id": "cncf-operator-framework",
+      "name": "Operator Framework",
+      "description": "OLM operator subscriptions, install plans, and catalog source status.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-operator-framework.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "OLM API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://operatorframework.io"
+      }
+    },
+    {
+      "id": "cncf-strimzi",
+      "name": "Strimzi",
+      "description": "Strimzi Kafka cluster health, topic status, and consumer group lag metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-strimzi.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "streaming",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Strimzi CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Streaming",
+        "website": "https://strimzi.io"
+      }
+    },
+    {
+      "id": "cncf-thanos",
+      "name": "Thanos",
+      "description": "Thanos global view metrics, store gateway status, and compactor health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-thanos.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "observability",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "Thanos API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Observability",
+        "website": "https://thanos.io"
+      }
+    },
+    {
+      "id": "cncf-volcano",
+      "name": "Volcano",
+      "description": "Volcano batch scheduling queues, job status, and GPU resource allocation.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-volcano.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "orchestration",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "intermediate",
+      "skills": [
+        "TypeScript",
+        "React",
+        "K8s CRDs"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Orchestration",
+        "website": "https://volcano.sh"
+      }
+    },
+    {
+      "id": "cncf-wasmcloud",
+      "name": "wasmCloud",
+      "description": "wasmCloud host status, actor inventory, and capability provider health.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-wasmcloud.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "runtime",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Runtime",
+        "website": "https://wasmcloud.com"
+      }
+    },
+    {
+      "id": "cncf-artifact-hub",
+      "name": "Artifact Hub",
+      "description": "Artifact Hub package discovery, repository sync status, and package statistics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-artifact-hub.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "app-definition",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "beginner",
+      "skills": [
+        "TypeScript",
+        "React",
+        "REST API"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "App Definition",
+        "website": "https://artifacthub.io"
+      }
+    },
+    {
+      "id": "cncf-flatcar",
+      "name": "Flatcar Container Linux",
+      "description": "Flatcar node OS versions, update status, and container-optimized host metrics.",
+      "author": "Community",
+      "version": "0.0.1",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-flatcar.json",
+      "tags": [
+        "cncf",
+        "incubating",
+        "provisioning",
+        "help-wanted"
+      ],
+      "cardCount": 1,
+      "type": "card-preset",
+      "status": "help-wanted",
+      "issueUrl": "",
+      "difficulty": "advanced",
+      "skills": [
+        "TypeScript",
+        "React"
+      ],
+      "cncfProject": {
+        "maturity": "incubating",
+        "category": "Provisioning",
+        "website": "https://www.flatcar.org"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **11 available** card presets for CNCF projects that already have card implementations (Kubernetes, Helm, Argo, Prometheus, OPA, Falco, cert-manager, Istio, Kyverno, Kubescape, OpenCost)
- Adds **57 help-wanted** skeleton entries for remaining CNCF graduated/incubating projects
- Each entry includes CNCF project metadata (maturity, category, website), difficulty rating, and required skills
- Registry version bumped to 2.0.0

## CNCF Coverage
| Category | Available | Help Wanted |
|---|---|---|
| Orchestration | 1 | 6 |
| App Definition | 2 | 7 |
| Observability | 1 | 5 |
| Security | 3 | 8 |
| Service Mesh | 1 | 2 |
| Runtime | 0 | 8 |
| Storage | 0 | 6 |
| Provisioning | 0 | 4 |
| Networking | 0 | 2 |
| Serverless | 0 | 2 |
| Streaming | 0 | 2 |

## Test plan
- [ ] Verify registry.json is valid JSON
- [ ] Verify all preset files are valid JSON
- [ ] Verify marketplace UI shows CNCF progress banner
- [ ] Verify help-wanted filter toggle works
- [ ] Verify "Contribute" button opens issue URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)