### PR TITLE
✨ Add CoreDNS card preset

### DIFF
--- a/presets/cncf-coredns.json
+++ b/presets/cncf-coredns.json
@@ -2,7 +2,5 @@
   "format": "kc-card-preset-v1",
   "card_type": "coredns_status",
   "title": "CoreDNS",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -447,19 +447,11 @@
       "tags": [
         "cncf",
         "graduated",
-        "orchestration",
-        "help-wanted"
+        "orchestration"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/5",
-      "difficulty": "beginner",
-      "skills": [
-        "TypeScript",
-        "React",
-        "DNS Metrics"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "graduated",
         "category": "Orchestration",


### PR DESCRIPTION
### Description

Update the CoreDNS marketplace preset and registry entry to reflect the completed card implementation in kubestellar/console#1184. The CoreDNS monitoring card (`coredns_status`) is now fully implemented with DNS query metrics, cache hit rates, and resolution performance monitoring.

### Related Issue

Fixes #5

### Changes Made

- [x] Removed `_placeholder` and `_help_wanted` fields from [presets/cncf-coredns.json](cci:7://file:///Users/harman/Desktop/console-marketplace/presets/cncf-coredns.json:0:0-0:0)
- [x] Updated [registry.json](cci:7://file:///Users/harman/Desktop/console-marketplace/registry.json:0:0-0:0): changed CoreDNS entry status from `help-wanted` to `available`
- [x] Removed `help-wanted` tag, `issueUrl`, `difficulty`, and `skills` fields from the CoreDNS registry entry

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

N/A — JSON-only changes to preset and registry files.

### Additional Notes

This PR accompanies the CoreDNS monitoring card implementation in kubestellar/console#1184, which adds the `coredns_status` card type to the console.