### PR TITLE
🐛 Fix nightly auto-QA JSON output and step failure

### DIFF
--- a/.github/workflows/marketplace-auto-qa.yml
+++ b/.github/workflows/marketplace-auto-qa.yml
@@ -42,9 +42,7 @@ jobs:
           python3 scripts/validate-marketplace.py \
             --mode full \
             --console-path ./console \
-            --json > /tmp/scan-results.json 2>/tmp/scan-log.txt
-
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+            --json > /tmp/scan-results.json 2>/tmp/scan-log.txt || true
 
           # Extract counts for issue creation
           ERROR_COUNT=$(python3 -c "import json; d=json.load(open('/tmp/scan-results.json')); print(len(d['errors']))")

--- a/scripts/validate-marketplace.py
+++ b/scripts/validate-marketplace.py
@@ -855,8 +855,11 @@ def main():
 
     console_path = os.path.abspath(args.console_path) if args.console_path else None
 
+    # When --json is used, send verbose progress to stderr so stdout is clean JSON
+    log = (lambda msg: print(msg, file=sys.stderr)) if args.json else print
+
     # ── Static checks (all modes) ──
-    print("=== Static Validation ===")
+    log("=== Static Validation ===")
     check_json_syntax(base, results)
     check_preset_schema(base, results)
     check_dashboard_schema(base, results)
@@ -867,7 +870,7 @@ def main():
     # ── Cross-repo checks ──
     known_types = set()
     if args.mode in ("cross-repo", "full") and console_path:
-        print("\n=== Cross-Repo Quality Checks ===")
+        log("\n=== Cross-Repo Quality Checks ===")
         known_types = check_card_type_existence(base, console_path, results)
         check_demo_data(base, console_path, known_types, results)
         check_is_demo_data_wiring(base, console_path, known_types, results)
@@ -877,7 +880,7 @@ def main():
 
     # ── Nightly-only checks ──
     if args.mode == "full":
-        print("\n=== Nightly Checks ===")
+        log("\n=== Nightly Checks ===")
         check_download_urls(base, results)
         check_registry_staleness(base, results)
         check_theme_consistency(base, results)
@@ -885,7 +888,6 @@ def main():
             check_cncf_coverage(base, console_path, results)
 
     # ── Output ──
-    print()
     if args.json:
         print(json.dumps(results.to_json(), indent=2))
     else:


### PR DESCRIPTION
## Summary
- Redirects verbose progress headers (`=== Static Validation ===`, etc.) to stderr when `--json` is used, keeping stdout as clean parseable JSON for CI
- Adds `|| true` to the scan command in the nightly workflow so bash continues after non-zero exit (the script exits 1 when errors are found, but the step still needs to extract error counts)

## Test plan
- [x] `python3 scripts/validate-marketplace.py --mode static --json 2>/dev/null | python3 -m json.tool` produces valid JSON
- [x] Verbose headers appear on stderr only
- [ ] Re-trigger nightly workflow after merge to verify end-to-end