### PR TITLE
🐛 Add github.token fallback for CONSOLE_AUTO secret

### DIFF
--- a/.github/workflows/marketplace-auto-qa.yml
+++ b/.github/workflows/marketplace-auto-qa.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Ensure labels exist
         if: steps.scan.outputs.error_count != '0' || steps.scan.outputs.warn_count != '0'
         env:
-          GH_TOKEN: ${{ secrets.CONSOLE_AUTO }}
+          GH_TOKEN: ${{ secrets.CONSOLE_AUTO || github.token }}
         run: |
           LABELS=(
             "auto-qa|0E8A16|Automated quality assurance finding"
@@ -153,7 +153,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          github-token: ${{ secrets.CONSOLE_AUTO }}
+          github-token: ${{ secrets.CONSOLE_AUTO || github.token }}
           script: |
             const fs = require('fs');
             const prefix = process.env.ISSUE_PREFIX;


### PR DESCRIPTION
## Summary
Adds `github.token` fallback for the `CONSOLE_AUTO` secret in the marketplace auto-QA workflow, providing resilience if the PAT expires or is removed.

Note: `CONSOLE_AUTO` has now been configured on the marketplace repo.