### PR TITLE
✨ Add copilot-setup-steps.yml to enable Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,37 @@
+name: Copilot Setup Steps
+# Pre-configures the Copilot coding agent's Ubuntu VM with tools needed
+# to validate and test marketplace changes (JSON presets, themes, dashboards).
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Checkout console (sparse, for validation)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: kubestellar/console
+          path: console
+          sparse-checkout: |
+            web/src/components/cards/cardRegistry.ts
+            web/src/components/cards
+            web/src/hooks
+            web/src/locales/en/cards.json
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate marketplace JSON
+        run: python3 scripts/validate-marketplace.py --mode full --console-path ./console || true
+
+      - name: Verify registry.json is valid JSON
+        run: python3 -m json.tool registry.json > /dev/null


### PR DESCRIPTION
## Problem

The Auto-QA workflow creates issues and tries to assign them to Copilot, but fails with:

> ⚠️ Could not assign Copilot coding agent: Forbidden

See [issue #77 comments](https://github.com/kubestellar/console-marketplace/issues/77#issuecomment-3936585827).

## Root Cause

The `copilot-setup-steps.yml` workflow file is **required** for the Copilot coding agent to accept issue assignments. The console repo has this file; console-marketplace was missing it.

## Fix

Adds `.github/workflows/copilot-setup-steps.yml` with:
- Python 3.12 setup for the validation script
- Sparse checkout of console repo (for cross-repo validation)
- JSON validation of `registry.json`

This enables Copilot to be assigned to Auto-QA issues and work on marketplace fixes autonomously.