### PR TITLE
fix: update registry.json updatedAt timestamp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "updatedAt": "2026-02-11T00:00:00Z",
+  "updatedAt": "2026-04-08T00:00:00Z",
   "items": [
     {
       "id": "sre-overview",


### PR DESCRIPTION
Fixes #96

Updated the registry.json `updatedAt` field from 2026-02-11 to 2026-04-08 to clear the staleness warning.