### PR TITLE
feat: activate OpenYurt card preset

### DIFF
--- a/presets/cncf-openyurt.json
+++ b/presets/cncf-openyurt.json
@@ -2,7 +2,5 @@
   "format": "kc-card-preset-v1",
   "card_type": "openyurt_status",
   "title": "OpenYurt",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -1791,17 +1791,17 @@
       "name": "OpenYurt",
       "description": "OpenYurt edge node pools, autonomy status, and edge-cloud connectivity.",
       "author": "Community",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-openyurt.json",
       "tags": [
         "cncf",
         "incubating",
         "orchestration",
-        "help-wanted"
+        "edge"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
+      "status": "available",
       "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/52",
       "difficulty": "intermediate",
       "skills": [


### PR DESCRIPTION
## Summary

Activates the **OpenYurt** card preset by removing placeholder flags and updating the registry, completing [#52](https://github.com/kubestellar/console-marketplace/issues/52).

- **`presets/cncf-openyurt.json`**: Removed `_placeholder` and `_help_wanted` fields — the preset now maps to the fully implemented `openyurt_status` card type
- **`registry.json`**: Changed status from `help-wanted` to `available`, bumped version to `1.0.0`, replaced `help-wanted` tag with `edge`

The card component implementation is in kubestellar/console#6183.

## Test Plan
- [ ] Verify the preset JSON is valid and installs into a fresh console
- [ ] Confirm the registry entry has `"status": "available"` and no `help-wanted` tag
- [ ] Verify the card renders correctly when the preset is loaded

Closes #52