### PR TITLE
feat: mark NATS card as available

### DIFF
--- a/presets/cncf-nats.json
+++ b/presets/cncf-nats.json
@@ -2,7 +2,5 @@
   "format": "kc-card-preset-v1",
   "card_type": "nats_status",
   "title": "NATS",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "config": {}
 }


### PR DESCRIPTION
## Summary
Updates the NATS card preset to mark it as available now that 
the card component has been implemented in kubestellar/console#5944.

## Changes
- Removed _placeholder and _help_wanted flags from presets/cncf-nats.json

## Validated
- python3 scripts/validate-marketplace.py → 0 errors, 0 warnings, 79 passed ✅

## Related
Resolves #47
Console PR: https://github.com/kubestellar/console/pull/5944