### PR TITLE
✨: add Lima card preset to marketplace

### DIFF
--- a/presets/cncf-lima.json
+++ b/presets/cncf-lima.json
@@ -2,7 +2,10 @@
   "format": "kc-card-preset-v1",
   "card_type": "lima_status",
   "title": "Lima",
+  "description": "Lima virtual machine instances, runtime health, and resource usage.",
+  "category": "Runtime",
+  "project": "lima",
+  "cncf_status": "incubating",
   "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "source": "console"
 }

--- a/registry.json
+++ b/registry.json
@@ -1586,23 +1586,16 @@
       "name": "Lima",
       "description": "Lima virtual machine instances, port forwarding status, and resource usage.",
       "author": "Community",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-lima.json",
       "tags": [
         "cncf",
         "incubating",
-        "runtime",
-        "help-wanted"
+        "runtime"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/44",
-      "difficulty": "beginner",
-      "skills": [
-        "TypeScript",
-        "React"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "incubating",
         "category": "Runtime",


### PR DESCRIPTION
## Summary
Updates the Lima card preset and registry metadata now that the card data layer is complete.

## Changes
- `presets/cncf-lima.json` — replaces placeholder with real `lima_status` preset
- `registry.json` — status changed from `help-wanted` to `available`; `help-wanted` tag removed

## Validation
- `validate-marketplace.py --mode static` ✅ (0 errors, 0 warnings)
- `validate-marketplace.py --mode cross-repo` ✅ (0 errors, 0 warnings)

## Related
Closes #44
Companion PR: kubestellar/console#9108
