### PR TITLE
feat: activate cncf-knative card preset

### DIFF
--- a/presets/cncf-knative.json
+++ b/presets/cncf-knative.json
@@ -2,7 +2,9 @@
   "format": "kc-card-preset-v1",
   "card_type": "knative_status",
   "title": "Knative",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "description": "Knative serving revisions, traffic routing, and eventing broker status.",
+  "category": "Serverless",
+  "project": "knative",
+  "cncf_status": "graduated",
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -1017,25 +1017,18 @@
       "id": "cncf-knative",
       "name": "Knative",
       "description": "Knative serving revisions, traffic routing, and eventing broker status.",
-      "author": "Community",
-      "version": "0.0.1",
+      "author": "kubestellar",
+      "authorGithub": "aashu2006",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-knative.json",
       "tags": [
         "cncf",
         "graduated",
-        "serverless",
-        "help-wanted"
+        "serverless"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/24",
-      "difficulty": "intermediate",
-      "skills": [
-        "TypeScript",
-        "React",
-        "Knative API"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "graduated",
         "category": "Serverless",


### PR DESCRIPTION
### Description

Activates the `cncf-knative` marketplace entry by changing its status from `help-wanted` to `available`, and replaces the placeholder preset file with the real card preset pointing to the `knative_status` card type implemented in the companion console PR.

### Related Issue

Fixes #24

### Changes Made

- [x] Updated `registry.json` — changed `cncf-knative` status from `help-wanted` to `available`, bumped version to `1.0.0`, set author to `kubestellar`, added `authorGithub: "aashu2006"`, removed help-wanted-only fields (`issueUrl`, `difficulty`, `skills`)
- [x] Updated `presets/cncf-knative.json` — replaced placeholder with real card preset (`card_type: "knative_status"`, added `description`, `category`, `project`, `cncf_status`)

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [x] `registry.json` validates as JSON
- [x] The `downloadUrl` points to the correct raw GitHub path
- [x] All commits are signed with DCO (`git commit -s`)

### Additional Notes

- Companion PR: kubestellar/console#9253 (implements the `knative_status` card component)