### PR TITLE
feat: activate Fluid monitoring card

### DIFF
--- a/presets/cncf-fluid.json
+++ b/presets/cncf-fluid.json
@@ -2,7 +2,9 @@
   "format": "kc-card-preset-v1",
   "card_type": "fluid_status",
   "title": "Fluid",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "description": "Fluid dataset caching status and data access acceleration metrics.",
+  "category": "Storage",
+  "project": "fluid",
+  "cncf_status": "incubating",
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -1383,26 +1383,19 @@
     {
       "id": "cncf-fluid",
       "name": "Fluid",
-      "description": "Fluid dataset caching status, runtime health, and data access acceleration metrics.",
-      "author": "Community",
-      "version": "0.0.1",
+      "description": "Fluid dataset caching status and data access acceleration metrics.",
+      "author": "kubestellar",
+      "authorGithub": "aashu2006",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-fluid.json",
       "tags": [
         "cncf",
         "incubating",
-        "storage",
-        "help-wanted"
+        "storage"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/37",
-      "difficulty": "intermediate",
-      "skills": [
-        "TypeScript",
-        "React",
-        "K8s CRDs"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "incubating",
         "category": "Storage",


### PR DESCRIPTION
### Description

Activate the Fluid monitoring card in the console marketplace. This is PR 2 of a 2-PR task - the card component (`fluid_status`) was implemented in kubestellar/console#9460 (PR 1), and this PR registers it as available in the marketplace.

**Fluid** is a CNCF incubating project for cloud-native dataset orchestration, enabling data-aware scheduling and acceleration for AI/Big Data workloads.

Fixes #37

### Changes Made

- [x] Updated `registry.json` - changed `cncf-fluid` status from `help-wanted` to `available`
- [x] Updated `registry.json` - set author to `kubestellar` / `aashu2006`, version to `1.0.0`, and removed `help-wanted` tag, `issueUrl`, `difficulty`, and `skills` fields
- [x] Updated `presets/cncf-fluid.json` - replaced placeholder with real card preset including `description`, `category`, `project`, and `cncf_status` fields

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Additional Notes

- The card component (`fluid_status`) and its preset file were implemented in PR 1 on `kubestellar/console`.
- The activation pattern follows the same approach used for `cncf-knative` and other activated cards.
- Both JSON files have been validated locally.