### PR TITLE
feat(marketplace): activate KServe preset as available

### DIFF
--- a/presets/cncf-kserve.json
+++ b/presets/cncf-kserve.json
@@ -2,7 +2,8 @@
   "format": "kc-card-preset-v1",
   "card_type": "kserve_status",
   "title": "KServe",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "description": "KServe inference service status, model serving metrics, and autoscaling health.",
+  "category": "Runtime",
+  "defaultSize": { "w": 6, "h": 4 },
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -1391,24 +1391,20 @@
       "name": "KServe",
       "description": "KServe inference service status, model serving metrics, and autoscaling health.",
       "author": "Community",
-      "version": "0.0.1",
+      "authorGithub": "XxSURYANSHxX",
+      "version": "0.1.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-kserve.json",
       "tags": [
         "cncf",
         "incubating",
         "runtime",
-        "help-wanted"
+        "inference",
+        "model-serving",
+        "monitoring"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/38",
-      "difficulty": "intermediate",
-      "skills": [
-        "TypeScript",
-        "React",
-        "K8s CRDs"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "incubating",
         "category": "Runtime",


### PR DESCRIPTION
## Summary
Activates the KServe marketplace preset now that kserve_status is implemented in console.

## Changes
- Updated presets/cncf-kserve.json from placeholder to real preset metadata
- Updated registry.json entry for cncf-kserve:
  - status: help-wanted -> available
  - version: 0.0.1 -> 0.1.0
  - removed issue/difficulty/skills fields
  - updated tags for runtime/model-serving monitoring

## Validation
- scripts/validate-marketplace.py --mode cross-repo --console-path ./console
  - 0 errors, 0 warnings

Companion console PR is from branch XxSURYANSHxX:feat/kserve-status-card in kubestellar/console.