### PR TITLE
feat: activate CubeFS monitoring card in marketplace

### DIFF
--- a/presets/cncf-cubefs.json
+++ b/presets/cncf-cubefs.json
@@ -2,7 +2,9 @@
   "format": "kc-card-preset-v1",
   "card_type": "cubefs_status",
   "title": "CubeFS",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "description": "CubeFS distributed file system health, volume status, and node topology.",
+  "category": "Storage",
+  "project": "cubefs",
+  "cncf_status": "graduated",
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -902,25 +902,18 @@
       "id": "cncf-cubefs",
       "name": "CubeFS",
       "description": "CubeFS distributed file system health, volume status, and metadata server metrics.",
-      "author": "Community",
-      "version": "0.0.1",
+      "author": "kubestellar",
+      "authorGithub": "aashu2006",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-cubefs.json",
       "tags": [
         "cncf",
         "graduated",
-        "storage",
-        "help-wanted"
+        "storage"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/20",
-      "difficulty": "advanced",
-      "skills": [
-        "TypeScript",
-        "React",
-        "CubeFS API"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "graduated",
         "category": "Storage",


### PR DESCRIPTION
### Description

Activates the CubeFS monitoring card in the console marketplace. The CubeFS card implementation (`cubefs_status`) PR has been done into the main console repo kubestellar/console#9871, so this PR updates the marketplace to make it available for installation.

### Related Issue

Fixes #20

### Changes Made

- [x] Updated `presets/cncf-cubefs.json` - replaced placeholder with full card preset config (`kc-card-preset-v1` format, `cubefs_status` card type)
- [x] Updated `registry.json` - changed `cncf-cubefs` status from `help-wanted` to `available`, updated author to `kubestellar`, version to `1.0.0`, and removed help-wanted-only fields (`issueUrl`, `difficulty`, `skills`, `help-wanted` tag)

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Additional Notes

- Follows the same activation pattern as `cncf-fluid` (PR #122) and `cncf-knative`.
- The `card_type: cubefs_status` matches the card ID registered in the console repo.
- Commit is DCO-signed.