### PR TITLE
feat: make cncf-chaos-mesh preset available

### DIFF
--- a/presets/cncf-chaos-mesh.json
+++ b/presets/cncf-chaos-mesh.json
@@ -2,7 +2,5 @@
   "format": "kc-card-preset-v1",
   "card_type": "chaos_mesh_status",
   "title": "Chaos Mesh",
-  "config": {},
-  "_placeholder": true,
-  "_help_wanted": "This card preset is a placeholder. See the associated GitHub issue for implementation instructions."
+  "config": {}
 }

--- a/registry.json
+++ b/registry.json
@@ -1325,25 +1325,18 @@
       "id": "cncf-chaos-mesh",
       "name": "Chaos Mesh",
       "description": "Chaos Mesh experiment status, workflow progress, and chaos injection schedules.",
-      "author": "Community",
-      "version": "0.0.1",
+      "author": "KubeStellar Team",
+      "version": "1.0.0",
       "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-chaos-mesh.json",
       "tags": [
         "cncf",
         "incubating",
         "runtime",
-        "help-wanted"
+        "chaos-engineering"
       ],
       "cardCount": 1,
       "type": "card-preset",
-      "status": "help-wanted",
-      "issueUrl": "https://github.com/kubestellar/console-marketplace/issues/36",
-      "difficulty": "intermediate",
-      "skills": [
-        "TypeScript",
-        "React",
-        "K8s CRDs"
-      ],
+      "status": "available",
       "cncfProject": {
         "maturity": "incubating",
         "category": "Runtime",


### PR DESCRIPTION
Resolves kubestellar/console#36.
Updates the preset status and metadata for the new Chaos Mesh card. Requires kubestellar/console#9892 to be merged.