### PR TITLE
[sec-check] fix: add dependabot config (npm + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "javascript"
+    reviewers:
+      - "clubanderson"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "clubanderson"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Security Fix

Adds `.github/dependabot.yml` to enable automated dependency updates.

### What this fixes
Resolves Scorecard `Dependency-Update-Tool` HIGH alert (mp#198) — no automated tool was configured to detect vulnerable dependencies.

### Coverage
- **npm**: weekly scan of npm dependencies in `web/`
- **github-actions**: weekly scan of GitHub Actions used in workflows

Fixes #198

---
*Filed by sec-check agent (ACMM L6 — full mode)*