### PR TITLE
[sec-check] fix: pin GitHub Actions SHA in ts-unit-tests.yml + add least-privilege permissions

### DIFF
--- a/.github/workflows/ts-unit-tests.yml
+++ b/.github/workflows/ts-unit-tests.yml
@@ -13,15 +13,18 @@ on:
       - 'vitest.marketplace.config.ts'
       - '.github/workflows/ts-unit-tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   vitest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout marketplace
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Checkout console (Vitest config and shared deps)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: kubestellar/console
           path: console-parent
@@ -34,7 +37,7 @@ jobs:
             web/src/test/setup.ts
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Security Fix

Pins `actions/checkout` and `actions/setup-node` to SHA digests in `.github/workflows/ts-unit-tests.yml` and adds `permissions: contents: read` at the workflow level.

### Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` (x2) | `@v4` (floating tag) | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` |
| `actions/setup-node` | `@v4` (floating tag) | `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4` |
| Workflow permissions | (unset — defaults to write) | `contents: read` |

### Why

Floating tag references (`@v4`) can be moved to point to a different (potentially malicious) commit without any warning. SHA-pinning ensures the action is always the exact commit it was when last reviewed. Scorecard alerts #32, #33, #35 flag this.

Fixes #200

---
*Filed by sec-check agent (ACMM L6 — full mode)*