### PR TITLE
[quality] Add unit tests for shared UI components (Select, ClusterBadge, Skeleton)

### DIFF
--- a/web/src/components/ui/__tests__/ClusterBadge.test.tsx
+++ b/web/src/components/ui/__tests__/ClusterBadge.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ClusterBadge } from '../ClusterBadge'
+
+describe('ClusterBadge', () => {
+  it('renders the cluster name as text content', () => {
+    render(<ClusterBadge cluster="eks-prod-us-east-1" />)
+    expect(screen.getByText('eks-prod-us-east-1')).toBeTruthy()
+  })
+
+  it('renders inside a span element', () => {
+    const { container } = render(<ClusterBadge cluster="gke-staging" />)
+    const span = container.querySelector('span')
+    expect(span).not.toBeNull()
+    expect(span?.textContent).toBe('gke-staging')
+  })
+
+  it('renders different cluster names correctly', () => {
+    const { rerender } = render(<ClusterBadge cluster="aks-dev-eu" />)
+    expect(screen.getByText('aks-dev-eu')).toBeTruthy()
+
+    rerender(<ClusterBadge cluster="kind-local" />)
+    expect(screen.getByText('kind-local')).toBeTruthy()
+    expect(screen.queryByText('aks-dev-eu')).toBeNull()
+  })
+
+  it('handles empty string cluster name', () => {
+    const { container } = render(<ClusterBadge cluster="" />)
+    const span = container.querySelector('span')
+    expect(span).not.toBeNull()
+    expect(span?.textContent).toBe('')
+  })
+})

--- a/web/src/components/ui/__tests__/Select.test.tsx
+++ b/web/src/components/ui/__tests__/Select.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Select } from '../Select'
+
+describe('Select', () => {
+  it('renders a native select element', () => {
+    render(<Select data-testid="test-select" />)
+    expect(screen.getByTestId('test-select').tagName).toBe('SELECT')
+  })
+
+  it('forwards HTML attributes to the underlying select', () => {
+    render(
+      <Select
+        data-testid="test-select"
+        aria-label="Choose cluster"
+        className="custom-class"
+        disabled
+      />,
+    )
+    const el = screen.getByTestId('test-select') as HTMLSelectElement
+    expect(el.getAttribute('aria-label')).toBe('Choose cluster')
+    expect(el.className).toContain('custom-class')
+    expect(el.disabled).toBe(true)
+  })
+
+  it('renders children as option elements', () => {
+    render(
+      <Select data-testid="test-select">
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </Select>,
+    )
+    const options = screen.getByTestId('test-select').querySelectorAll('option')
+    expect(options).toHaveLength(2)
+    expect(options[0]?.textContent).toBe('Alpha')
+    expect(options[1]?.textContent).toBe('Beta')
+  })
+
+  it('fires onChange when the value changes', () => {
+    const onChange = vi.fn()
+    render(
+      <Select data-testid="test-select" onChange={onChange}>
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </Select>,
+    )
+    fireEvent.change(screen.getByTestId('test-select'), { target: { value: 'b' } })
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('reflects value prop as the selected value', () => {
+    render(
+      <Select data-testid="test-select" value="b" onChange={() => {}}>
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </Select>,
+    )
+    const el = screen.getByTestId('test-select') as HTMLSelectElement
+    expect(el.value).toBe('b')
+  })
+})

--- a/web/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/web/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Skeleton, SkeletonStats, SkeletonList } from '../Skeleton'
+
+describe('Skeleton', () => {
+  it('renders a div with data-testid="skeleton"', () => {
+    render(<Skeleton />)
+    expect(screen.getByTestId('skeleton')).toBeTruthy()
+  })
+
+  it('forwards HTML attributes to the div', () => {
+    render(<Skeleton className="animate-pulse w-full" aria-label="Loading" />)
+    const el = screen.getByTestId('skeleton')
+    expect(el.className).toContain('animate-pulse')
+    expect(el.getAttribute('aria-label')).toBe('Loading')
+  })
+
+  it('renders children inside the skeleton div', () => {
+    render(
+      <Skeleton>
+        <span>child</span>
+      </Skeleton>,
+    )
+    expect(screen.getByText('child')).toBeTruthy()
+  })
+})
+
+describe('SkeletonStats', () => {
+  it('renders a div with data-testid="skeleton-stats"', () => {
+    render(<SkeletonStats />)
+    expect(screen.getByTestId('skeleton-stats')).toBeTruthy()
+  })
+
+  it('forwards className to the div', () => {
+    render(<SkeletonStats className="h-12" />)
+    const el = screen.getByTestId('skeleton-stats')
+    expect(el.className).toContain('h-12')
+  })
+})
+
+describe('SkeletonList', () => {
+  it('renders a div with data-testid="skeleton-list"', () => {
+    render(<SkeletonList />)
+    expect(screen.getByTestId('skeleton-list')).toBeTruthy()
+  })
+
+  it('forwards className and style to the div', () => {
+    render(<SkeletonList className="space-y-2" style={{ maxHeight: '200px' }} />)
+    const el = screen.getByTestId('skeleton-list')
+    expect(el.className).toContain('space-y-2')
+    expect(el.style.maxHeight).toBe('200px')
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for the 3 shared UI components in `web/src/components/ui/` that previously had zero test coverage:

| Component | Tests | Coverage |
|-----------|-------|----------|
| `Select.tsx` | renders native select, forwards props/children, handles onChange, reflects value | 5 tests |
| `ClusterBadge.tsx` | renders cluster name, handles rerender, empty string | 4 tests |
| `Skeleton.tsx` | renders Skeleton/SkeletonStats/SkeletonList with testids, forwards attrs | 6 tests |

## Context

These components are reused across all card components (OpenKruise, Notary, Kubeflow, OpenYurt) and were the only shared UI components without dedicated tests.

**Coverage delta**: +3 files covered (~+2% component-level coverage)

Closes partially: #214

---
*Filed by quality agent (ACMM L6)*