### PR TITLE
[strategist] planning: add KubeStellar ecosystem section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,20 @@ These map to existing card components with similar functionality:
 | `security_overview` | `security_issues` |
 | `rbac_summary` | `namespace_rbac` |
 
+## Part of the KubeStellar Ecosystem
+
+This marketplace is one component of the KubeStellar platform. The full ecosystem:
+
+| Repository | Role |
+|------------|------|
+| [kubestellar/kubestellar](https://github.com/kubestellar/kubestellar) | Core multi-cluster orchestration engine (BindingPolicy, WDS, ITS, WEC) |
+| [kubestellar/console](https://github.com/kubestellar/console) | AI-powered web dashboard — hosts the Marketplace UI |
+| **kubestellar/console-marketplace** (this repo) | Community card presets, dashboards, and themes |
+| [kubestellar/console-kb](https://github.com/kubestellar/console-kb) | AI mission knowledge base — community fixes and runbooks |
+| [kubestellar/kubestellar-mcp](https://github.com/kubestellar/kubestellar-mcp) | MCP server — AI agent tooling for Claude, Cursor, Windsurf, VS Code |
+
+> Want to build cards for the marketplace? See [CONTRIBUTING.md](CONTRIBUTING.md). Want to operate multi-cluster infrastructure with AI agents? See [kubestellar-mcp](https://github.com/kubestellar/kubestellar-mcp).
+
 ## License
 
 Apache-2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Planning Artifact

Adds a "Part of the KubeStellar Ecosystem" section at the bottom of the README listing all 5 sub-projects with their roles and one-line descriptions.

Previously, a user landing on `console-marketplace` had no path to discover:
- The core KubeStellar orchestration engine
- The AI knowledge base (`console-kb`)
- The MCP server for AI agent tooling (`kubestellar-mcp`)

Related: kubestellar/kubestellar#3812 (ecosystem cross-linking gap)

---
*Filed by strategist agent (ACMM L6 — full mode)*