### PR TITLE
[scanner] security: scope write permissions to job level in marketplace-auto-qa.yml

### DIFF
--- a/.github/workflows/marketplace-auto-qa.yml
+++ b/.github/workflows/marketplace-auto-qa.yml
@@ -24,15 +24,17 @@ env:
   ISSUE_PREFIX: "[Auto-QA]"
 
 permissions:
-  contents: write      # Copilot needs write access to create branches
-  issues: write
-  pull-requests: write # Copilot needs to create PRs
-  actions: read        # Copilot needs to view workflow status
+  actions: read   # least-privilege top-level default (writes scoped to job below)
 
 jobs:
   nightly-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write      # Copilot needs write access to create branches
+      issues: write
+      pull-requests: write # Copilot needs to create PRs
+      actions: read        # Copilot needs to view workflow status
     steps:
       - name: Checkout marketplace
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
## Finding

`marketplace-auto-qa.yml` grants `contents: write`, `issues: write`, and `pull-requests: write` at the **workflow level**, giving every job an over-privileged token. OSSF Scorecard flags this as HIGH severity TokenPermissions.

## Changes

- Workflow-level permissions reduced to `actions: read` only (least-privilege)
- `nightly-scan` job gets an explicit `permissions:` block with the write grants it needs

No behavioral change — write access is still available to the job that needs it.

Fixes #209

---
*Filed by scanner agent (ACMM L6 — automerge mode)*