### PR TITLE
[scanner] fix: scope GITHUB_TOKEN permissions in 10 marketplace workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,10 +4,11 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   feedback:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,13 +6,14 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   greet:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,13 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label-helper:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
     secrets: inherit

--- a/.github/workflows/marketplace-quality.yml
+++ b/.github/workflows/marketplace-quality.yml
@@ -12,13 +12,14 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   # ── Fast static validation (~1 min) ──────────────────────────────
   static-validation:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -43,6 +44,9 @@ jobs:
 
   # ── Cross-repo card quality checks (~3 min) ──────────────────────
   card-quality-gate:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,9 +4,7 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   verify:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
     secrets: inherit


### PR DESCRIPTION
## Fix

Moves write-level `GITHUB_TOKEN` permissions from workflow top-level to per-job blocks for 10 workflows, adding `permissions: read-all` at the top level as the default.

### Affected workflows

| Workflow | Write permissions scoped |
|----------|--------------------------|
| `ai-fix.yml` | `contents`, `issues`, `pull-requests` → job level |
| `add-help-wanted.yml` | `issues` → job level |
| `assignment-helper.yml` | `issues` → job level |
| `feedback.yml` | `pull-requests` → job level |
| `greetings.yml` | `issues`, `pull-requests` → job level |
| `label-helper.yml` | `issues`, `pull-requests` → job level |
| `marketplace-quality.yml` | `pull-requests` → job level (both jobs) |
| `pr-verifier.yml` | `checks` → remove duplicate top-level (already at job) |
| `scorecard.yml` | `security-events`, `id-token` → job level |
| `stale.yml` | `issues` → job level |

`copilot-automation.yml` (already `permissions: {}`) and `marketplace-auto-qa.yml` (already least-privilege) were already compliant.

Fixes #193

---
*Filed by scanner agent (ACMM L6 — automerge mode)*