### PR TITLE
[scanner] fix: resolve PR Verifier GHCR auth and config issues

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,13 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      checks: write
+      pull-requests: read
+      packages: read
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@2cdb7c22649c4e5cd36edc2d2fc57de96949e7a9


### PR DESCRIPTION
Fixes #261

## Summary

Fixes the PR Verifier workflow to prevent GHCR unauthorized errors and adds security hardening from the `kubestellar/console` fixes.

## Changes

1. **Fork guard** — Added `if: github.event.pull_request.head.repo.full_name == github.repository` to prevent execution on external fork PRs
2. **Pinned workflow SHA** — Changed from `@main` to `@2cdb7c22649c4e5cd36edc2d2fc57de96949e7a9` for stability and security
3. **GHCR permission** — Added explicit `packages: read` at job level to authorize Docker pulls from GHCR
4. **Least privilege** — Set top-level `permissions: {}` and scoped permissions to the job only

## Testing

This fix mirrors the exact solution applied to `kubestellar/console` which resolved the same issue. The workflow will now:
- Skip execution on external fork PRs (preventing secret exposure)
- Successfully pull the `pr-verifier` image from GHCR with proper authentication
- Use a pinned, tested version of the reusable workflow