### PR TITLE
🌱 [scanner] fix: secure pull_request_target workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
Fixes #280
Fixes #281

## Summary

This PR addresses security vulnerabilities in two GitHub workflow files that use `pull_request_target` with write permissions but lacked fork guards.

## Changes

### `.github/workflows/ai-fix.yml`
- Added fork guard: `if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository`
- Prevents pwn-request attacks where malicious fork PRs could execute with elevated permissions

### `.github/workflows/copilot-automation.yml`
- Added fork guard: `if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository`
- Ensures workflow only runs with write permissions when triggered from the same repository

## Security Impact

Without these guards, an attacker could:
1. Fork the repository
2. Create a malicious PR with modified workflow code
3. Execute arbitrary code with `contents`, `issues`, `pull-requests`, and `statuses` write permissions
4. Potentially compromise the repository

With these guards in place, `pull_request_target` workflows from forks will be skipped, preventing privilege escalation attacks.