### PR TITLE
[scanner] fix: harden workflow security (greetings + pr-verifier)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,4 +14,3 @@ permissions:
 jobs:
   greet:
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   verify:
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit


### PR DESCRIPTION
Fixes #298, Fixes #299

Hardens pull_request_target workflows by removing unnecessary secrets exposure.

- **greetings.yml**: Removed `secrets: inherit` as the reusable workflow only needs `github.token` (provided automatically)
- **pr-verifier.yml**: Removed `secrets: inherit` to prevent fork PRs from accessing repository secrets