### PR TITLE
[scanner] fix: add permissions block to copilot-dco.yml

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
Fixes #301

Adds explicit `permissions: pull-requests: read` to copilot-dco.yml per OpenSSF Scorecard TokenPermissions recommendation.