### PR TITLE
[sec-check] fix: restrict GITHUB_TOKEN permissions to least privilege

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - '.github/workflows/**'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   actionlint:

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,7 +12,10 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   ai-fix:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/marketplace-quality.yml
+++ b/.github/workflows/marketplace-quality.yml
@@ -12,7 +12,8 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 
 jobs:
   # ── Fast static validation (~1 min) ──────────────────────────────


### PR DESCRIPTION
## Summary
This PR addresses security issue #304 by restricting overly broad GITHUB_TOKEN permissions in 4 workflows:

- **actionlint.yml**: Changed from `read-all` to `contents: read`
- **copilot-automation.yml**: Changed from `read-all` to `contents: read, pull-requests: read, issues: read`
- **ai-fix.yml**: Changed from `read-all` to `contents: read, issues: read, pull-requests: read`
- **marketplace-quality.yml**: Changed from `read-all` to `contents: read`

## Changes Made
Applied least-privilege permissions to all workflows, restricting token scope to only what's needed. Job-level permissions already override these for operations requiring write access.

## References
Closes #304