### PR TITLE
[quality] test: add 24 shape/contract tests for marketplace card demoData

### DIFF
--- a/web/src/components/cards/kubeflow_status/demoData.test.ts
+++ b/web/src/components/cards/kubeflow_status/demoData.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { KUBEFLOW_DEMO_DATA } from './demoData'
+
+describe('KUBEFLOW_DEMO_DATA', () => {
+  it('contains pipeline runs with required fields', () => {
+    expect(KUBEFLOW_DEMO_DATA.pipelineRuns.length).toBeGreaterThan(0)
+
+    const validStatuses = ['succeeded', 'failed', 'running', 'pending', 'skipped', 'error']
+    for (const run of KUBEFLOW_DEMO_DATA.pipelineRuns) {
+      expect(run.id).toBeTruthy()
+      expect(run.name).toBeTruthy()
+      expect(run.pipelineName).toBeTruthy()
+      expect(run.experiment).toBeTruthy()
+      expect(run.namespace).toBeTruthy()
+      expect(run.cluster).toBeTruthy()
+      expect(validStatuses).toContain(run.status)
+      expect(new Date(run.createdAt).toString()).not.toBe('Invalid Date')
+      expect(typeof run.metrics).toBe('object')
+    }
+  })
+
+  it('contains experiments with required fields', () => {
+    expect(KUBEFLOW_DEMO_DATA.experiments.length).toBeGreaterThan(0)
+
+    for (const exp of KUBEFLOW_DEMO_DATA.experiments) {
+      expect(exp.id).toBeTruthy()
+      expect(exp.name).toBeTruthy()
+      expect(exp.namespace).toBeTruthy()
+      expect(exp.cluster).toBeTruthy()
+      expect(typeof exp.totalRuns).toBe('number')
+      expect(typeof exp.succeededRuns).toBe('number')
+      expect(typeof exp.failedRuns).toBe('number')
+      expect(typeof exp.activeRuns).toBe('number')
+      expect(new Date(exp.lastRunAt).toString()).not.toBe('Invalid Date')
+    }
+  })
+
+  it('contains notebooks with required fields', () => {
+    expect(KUBEFLOW_DEMO_DATA.notebooks.length).toBeGreaterThan(0)
+
+    const validServerTypes = ['jupyter', 'rstudio', 'vscode']
+    const validStatuses = ['running', 'stopped', 'pending', 'terminating', 'error']
+    for (const nb of KUBEFLOW_DEMO_DATA.notebooks) {
+      expect(nb.name).toBeTruthy()
+      expect(nb.namespace).toBeTruthy()
+      expect(nb.cluster).toBeTruthy()
+      expect(validServerTypes).toContain(nb.serverType)
+      expect(validStatuses).toContain(nb.status)
+      expect(nb.image).toBeTruthy()
+      expect(nb.cpu).toBeTruthy()
+      expect(nb.memory).toBeTruthy()
+      expect(typeof nb.gpu).toBe('number')
+    }
+  })
+
+  it('contains training jobs with required fields', () => {
+    expect(KUBEFLOW_DEMO_DATA.trainingJobs.length).toBeGreaterThan(0)
+
+    for (const job of KUBEFLOW_DEMO_DATA.trainingJobs) {
+      expect(job.name).toBeTruthy()
+      expect(job.namespace).toBeTruthy()
+      expect(job.cluster).toBeTruthy()
+      expect(job.framework).toBeTruthy()
+    }
+  })
+
+  it('has valid aggregate fields', () => {
+    expect(typeof KUBEFLOW_DEMO_DATA.totalPipelines).toBe('number')
+    expect(typeof KUBEFLOW_DEMO_DATA.totalActiveRuns).toBe('number')
+    expect(typeof KUBEFLOW_DEMO_DATA.totalExperiments).toBe('number')
+    expect(typeof KUBEFLOW_DEMO_DATA.overallSuccessRate).toBe('number')
+    expect(KUBEFLOW_DEMO_DATA.overallSuccessRate).toBeGreaterThanOrEqual(0)
+    expect(KUBEFLOW_DEMO_DATA.overallSuccessRate).toBeLessThanOrEqual(1)
+  })
+
+  it('sets a valid lastCheckTime timestamp', () => {
+    expect(new Date(KUBEFLOW_DEMO_DATA.lastCheckTime).toString()).not.toBe('Invalid Date')
+  })
+})

--- a/web/src/components/cards/notary_status/demoData.test.ts
+++ b/web/src/components/cards/notary_status/demoData.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { NOTARY_DEMO_DATA } from './demoData'
+
+describe('NOTARY_DEMO_DATA', () => {
+  it('contains clusters with required fields', () => {
+    expect(NOTARY_DEMO_DATA.clusters.length).toBeGreaterThan(0)
+
+    for (const cluster of NOTARY_DEMO_DATA.clusters) {
+      expect(cluster.cluster).toBeTruthy()
+      expect(typeof cluster.installed).toBe('boolean')
+      expect(typeof cluster.signedImages).toBe('number')
+      expect(typeof cluster.unsignedImages).toBe('number')
+      expect(Array.isArray(cluster.trustPolicies)).toBe(true)
+    }
+  })
+
+  it('trust policies have valid signature verification levels', () => {
+    const validLevels = ['strict', 'permissive', 'audit']
+    for (const cluster of NOTARY_DEMO_DATA.clusters) {
+      for (const policy of cluster.trustPolicies) {
+        expect(policy.name).toBeTruthy()
+        expect(Array.isArray(policy.registryScopes)).toBe(true)
+        expect(policy.registryScopes.length).toBeGreaterThan(0)
+        expect(validLevels).toContain(policy.signatureVerification)
+      }
+    }
+  })
+
+  it('includes at least one installed and one not-installed cluster', () => {
+    const installed = NOTARY_DEMO_DATA.clusters.filter(c => c.installed)
+    const notInstalled = NOTARY_DEMO_DATA.clusters.filter(c => !c.installed)
+    expect(installed.length).toBeGreaterThan(0)
+    expect(notInstalled.length).toBeGreaterThan(0)
+  })
+
+  it('sets a valid lastCheckTime timestamp', () => {
+    expect(new Date(NOTARY_DEMO_DATA.lastCheckTime).toString()).not.toBe('Invalid Date')
+  })
+})

--- a/web/src/components/cards/openkruise_status/demoData.test.ts
+++ b/web/src/components/cards/openkruise_status/demoData.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { OPENKRUISE_DEMO_DATA } from './demoData'
+
+describe('OPENKRUISE_DEMO_DATA', () => {
+  it('contains CloneSets with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.cloneSets.length).toBeGreaterThan(0)
+
+    const validStatuses = ['healthy', 'updating', 'degraded', 'failed']
+    const validStrategies = ['ReCreate', 'InPlaceIfPossible', 'InPlaceOnly']
+    for (const cs of OPENKRUISE_DEMO_DATA.cloneSets) {
+      expect(cs.name).toBeTruthy()
+      expect(cs.namespace).toBeTruthy()
+      expect(cs.cluster).toBeTruthy()
+      expect(typeof cs.replicas).toBe('number')
+      expect(typeof cs.readyReplicas).toBe('number')
+      expect(validStatuses).toContain(cs.status)
+      expect(validStrategies).toContain(cs.updateStrategy)
+      expect(cs.image).toBeTruthy()
+      expect(new Date(cs.updatedAt).toString()).not.toBe('Invalid Date')
+    }
+  })
+
+  it('contains Advanced StatefulSets with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.advancedStatefulSets.length).toBeGreaterThan(0)
+
+    for (const ss of OPENKRUISE_DEMO_DATA.advancedStatefulSets) {
+      expect(ss.name).toBeTruthy()
+      expect(ss.namespace).toBeTruthy()
+      expect(ss.cluster).toBeTruthy()
+      expect(typeof ss.replicas).toBe('number')
+      expect(typeof ss.readyReplicas).toBe('number')
+      expect(['healthy', 'updating', 'degraded', 'failed']).toContain(ss.status)
+      expect(['RollingUpdate', 'InPlaceIfPossible', 'InPlaceOnly']).toContain(ss.updateStrategy)
+    }
+  })
+
+  it('contains Advanced DaemonSets with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.advancedDaemonSets.length).toBeGreaterThan(0)
+
+    for (const ds of OPENKRUISE_DEMO_DATA.advancedDaemonSets) {
+      expect(ds.name).toBeTruthy()
+      expect(ds.namespace).toBeTruthy()
+      expect(ds.cluster).toBeTruthy()
+      expect(typeof ds.desiredNumber).toBe('number')
+      expect(typeof ds.readyNumber).toBe('number')
+      expect(['healthy', 'updating', 'degraded', 'failed']).toContain(ds.status)
+    }
+  })
+
+  it('contains SidecarSets with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.sidecarSets.length).toBeGreaterThan(0)
+
+    for (const ss of OPENKRUISE_DEMO_DATA.sidecarSets) {
+      expect(ss.name).toBeTruthy()
+      expect(ss.namespace).toBeTruthy()
+      expect(ss.cluster).toBeTruthy()
+      expect(typeof ss.matchedPods).toBe('number')
+      expect(typeof ss.injectedPods).toBe('number')
+      expect(typeof ss.readyPods).toBe('number')
+      expect(['healthy', 'updating', 'degraded']).toContain(ss.status)
+    }
+  })
+
+  it('contains BroadcastJobs with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.broadcastJobs.length).toBeGreaterThan(0)
+
+    for (const bj of OPENKRUISE_DEMO_DATA.broadcastJobs) {
+      expect(bj.name).toBeTruthy()
+      expect(bj.namespace).toBeTruthy()
+      expect(bj.cluster).toBeTruthy()
+      expect(typeof bj.desiredNodes).toBe('number')
+      expect(typeof bj.succeededNodes).toBe('number')
+      expect(typeof bj.failedNodes).toBe('number')
+      expect(['completed', 'running', 'failed', 'paused']).toContain(bj.status)
+    }
+  })
+
+  it('contains AdvancedCronJobs with required fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.advancedCronJobs.length).toBeGreaterThan(0)
+
+    for (const cj of OPENKRUISE_DEMO_DATA.advancedCronJobs) {
+      expect(cj.name).toBeTruthy()
+      expect(cj.namespace).toBeTruthy()
+      expect(cj.cluster).toBeTruthy()
+      expect(cj.schedule).toBeTruthy()
+      expect(typeof cj.activeJobs).toBe('number')
+      expect(typeof cj.successfulJobs).toBe('number')
+      expect(typeof cj.failedJobs).toBe('number')
+      expect(['active', 'suspended', 'error']).toContain(cj.status)
+    }
+  })
+
+  it('has valid aggregate fields', () => {
+    expect(OPENKRUISE_DEMO_DATA.controllerVersion).toBeTruthy()
+    expect(typeof OPENKRUISE_DEMO_DATA.totalInjectedPods).toBe('number')
+    expect(OPENKRUISE_DEMO_DATA.totalInjectedPods).toBeGreaterThan(0)
+  })
+
+  it('sets a valid lastCheckTime timestamp', () => {
+    expect(new Date(OPENKRUISE_DEMO_DATA.lastCheckTime).toString()).not.toBe('Invalid Date')
+  })
+})

--- a/web/src/components/cards/openyurt_status/demoData.test.ts
+++ b/web/src/components/cards/openyurt_status/demoData.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { OPENYURT_DEMO_DATA } from './demoData'
+
+describe('OPENYURT_DEMO_DATA', () => {
+  it('has a valid health status', () => {
+    expect(['healthy', 'degraded', 'not-installed']).toContain(OPENYURT_DEMO_DATA.health)
+  })
+
+  it('has valid controller pod counts', () => {
+    expect(typeof OPENYURT_DEMO_DATA.controllerPods.ready).toBe('number')
+    expect(typeof OPENYURT_DEMO_DATA.controllerPods.total).toBe('number')
+    expect(OPENYURT_DEMO_DATA.controllerPods.ready).toBeLessThanOrEqual(
+      OPENYURT_DEMO_DATA.controllerPods.total
+    )
+  })
+
+  it('contains node pools with required fields', () => {
+    expect(OPENYURT_DEMO_DATA.nodePools.length).toBeGreaterThan(0)
+
+    const validTypes = ['edge', 'cloud']
+    const validStatuses = ['ready', 'degraded', 'not-ready']
+    for (const pool of OPENYURT_DEMO_DATA.nodePools) {
+      expect(pool.name).toBeTruthy()
+      expect(validTypes).toContain(pool.type)
+      expect(validStatuses).toContain(pool.status)
+      expect(typeof pool.nodeCount).toBe('number')
+      expect(typeof pool.readyNodes).toBe('number')
+      expect(typeof pool.autonomyEnabled).toBe('boolean')
+      expect(pool.readyNodes).toBeLessThanOrEqual(pool.nodeCount)
+    }
+  })
+
+  it('contains gateways with required fields', () => {
+    expect(OPENYURT_DEMO_DATA.gateways.length).toBeGreaterThan(0)
+
+    const validStatuses = ['connected', 'disconnected', 'pending']
+    for (const gw of OPENYURT_DEMO_DATA.gateways) {
+      expect(gw.name).toBeTruthy()
+      expect(gw.nodePool).toBeTruthy()
+      expect(validStatuses).toContain(gw.status)
+      expect(gw.endpoint).toBeTruthy()
+    }
+  })
+
+  it('has valid aggregate node counts', () => {
+    expect(typeof OPENYURT_DEMO_DATA.totalNodes).toBe('number')
+    expect(typeof OPENYURT_DEMO_DATA.autonomousNodes).toBe('number')
+    expect(OPENYURT_DEMO_DATA.totalNodes).toBeGreaterThan(0)
+    expect(OPENYURT_DEMO_DATA.autonomousNodes).toBeLessThanOrEqual(
+      OPENYURT_DEMO_DATA.totalNodes
+    )
+  })
+
+  it('sets a valid lastCheckTime timestamp', () => {
+    expect(new Date(OPENYURT_DEMO_DATA.lastCheckTime).toString()).not.toBe('Invalid Date')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds **24 shape/contract tests** across 4 new test files for marketplace card `demoData.ts` files that had zero test coverage. Follows the existing pattern from `buildpacks-status` and `coredns_status`.

### Test files added

| Card | Tests | What's validated |
|------|-------|-----------------|
| `notary_status/demoData.test.ts` | 4 | Cluster fields, trust policy verification levels, install states, timestamps |
| `openyurt_status/demoData.test.ts` | 6 | Health status, controller pods, node pools (type/status/autonomy), gateways, node counts, timestamps |
| `kubeflow_status/demoData.test.ts` | 6 | Pipeline runs, experiments, notebooks (server types/statuses), training jobs, aggregates, timestamps |
| `openkruise_status/demoData.test.ts` | 8 | CloneSets, StatefulSets, DaemonSets, SidecarSets, BroadcastJobs, CronJobs, aggregates, timestamps |

### What these tests catch
- Missing or renamed fields in demo data objects
- Invalid enum values (status, type, strategy fields)
- Type mismatches (string vs number)
- Invalid timestamps
- Empty arrays that should have demo entries

## Related Issue
Fixes #313

---
*Filed by quality agent (hold-gated mode). Human review required.*