### PR TITLE
[sec-check] fix: resolve 17 CodeQL js/unused-local-variable alerts in card components

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -13,7 +13,6 @@ export function useCardLoadingState(opts?: CardLoadingStateOptions) {
     isLoading = false,
     isRefreshing = false,
     hasAnyData = true,
-    isFailed = false,
     isDemoData = false,
   } = opts ?? {}
 

--- a/web/src/components/cards/coredns_status/demoData.ts
+++ b/web/src/components/cards/coredns_status/demoData.ts
@@ -10,7 +10,6 @@
 /** Time offsets (in milliseconds) used for relative timestamps. */
 const ONE_MINUTE_MS = 60 * 1000
 const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS
-const ONE_HOUR_MS = 60 * ONE_MINUTE_MS
 
 export interface CoreDNSDemoServer {
   name: string

--- a/web/src/components/cards/kubeflow_status/index.tsx
+++ b/web/src/components/cards/kubeflow_status/index.tsx
@@ -11,7 +11,6 @@ import {
   BookOpen,
   Cpu,
 } from 'lucide-react'
-import { useClusters } from '../../hooks/useMCP'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import {
@@ -58,25 +57,6 @@ type SortTranslationKey =
   | 'cards:kubeflowStatus.category'
   | 'cards:kubeflowStatus.updated'
 
-const STATUS_ORDER: Record<string, number> = {
-  failed: 0,
-  error: 0,
-  degraded: 1,
-  restarting: 1,
-  pending: 2,
-  created: 2,
-  terminating: 2,
-  suspended: 3,
-  running: 4,
-  active: 4,
-  building: 4,
-  succeeded: 5,
-  healthy: 5,
-  stopped: 6,
-  idle: 6,
-  skipped: 7,
-}
-
 const SORT_OPTIONS_KEYS: ReadonlyArray<{
   value: SortByOption
   labelKey: SortTranslationKey
@@ -104,7 +84,6 @@ export function KubeflowStatus({ config }: KubeflowStatusProps) {
   // --- 4. useTranslation       (required hook #4, already called above) ---
   // --- 5. isDemoData wiring    (required pattern #5, see below) ---
 
-  const { isLoading: clustersLoading } = useClusters()
   const { isDemoMode } = useDemoMode()
   const { selectedClusters } = useGlobalFilters()
 
@@ -121,7 +100,7 @@ export function KubeflowStatus({ config }: KubeflowStatusProps) {
   const rawData: KubeflowDemoData = KUBEFLOW_DEMO_DATA
 
   // #1 + #5  Report loading / demo state to CardWrapper
-  const { showSkeleton, showEmptyState } = useCardLoadingState()
+  const { showSkeleton, showEmptyState } = useCardLoadingState({ isDemoData })
 
   // Transform every Kubeflow resource into a unified display item -----
   const allItems = useMemo<KubeflowDisplayItem[]>(() => {

--- a/web/src/components/cards/notary_status/index.tsx
+++ b/web/src/components/cards/notary_status/index.tsx
@@ -59,7 +59,7 @@ export function NotaryStatus({ config: _config }: NotaryStatusProps) {
   const rawData: NotaryDemoData = NOTARY_DEMO_DATA
 
   // --- required hook #1 + pattern #5: wire isDemoData into useCardLoadingState ---
-  const { showSkeleton, showEmptyState } = useCardLoadingState()
+  const { showSkeleton, showEmptyState } = useCardLoadingState({ isDemoData })
 
   // Flatten clusters into display rows
   const allRows = useMemo<NotaryDisplayRow[]>(() => {

--- a/web/src/components/cards/openkruise_status/index.tsx
+++ b/web/src/components/cards/openkruise_status/index.tsx
@@ -16,7 +16,6 @@ import {
   ExternalLink,
   PauseCircle,
 } from 'lucide-react'
-import { useClusters } from '../../../hooks/useMCP'
 import { Skeleton } from '../../ui/Skeleton'
 import { Select } from '../../ui/Select'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -75,20 +74,6 @@ type SortTranslationKey =
   | 'cards:openkruiseStatus.category'
   | 'cards:openkruiseStatus.updated'
 
-const STATUS_ORDER: Record<string, number> = {
-  failed: 0,
-  error: 0,
-  degraded: 1,
-  pending: 2,
-  paused: 2,
-  suspended: 3,
-  updating: 3,
-  running: 4,
-  active: 4,
-  succeeded: 5,
-  healthy: 5,
-}
-
 // Static Tailwind class maps so the JIT can statically detect the classes.
 const ICON_COLOR_CLASS: Record<string, string> = {
   green: 'text-green-400',
@@ -136,7 +121,6 @@ export function OpenKruiseStatus({ config: _config }: OpenKruiseStatusProps) {
   )
 
   // --- Required hooks ---
-  const { isLoading: clustersLoading } = useClusters()
   const { isDemoMode } = useDemoMode()
   const { selectedClusters } = useGlobalFilters()
 
@@ -151,18 +135,14 @@ export function OpenKruiseStatus({ config: _config }: OpenKruiseStatusProps) {
   const {
     data: rawData,
     isLoading: dataLoading,
-    isRefreshing,
-    isFailed,
     isDemoFallback,
-    consecutiveFailures,
-    lastRefresh,
   } = useOpenKruiseStatus()
 
   // isDemoData is true whenever we're showing demo-sourced data — explicit
   // demo mode or the live fetcher fell back.
   const isDemoData = isDemoMode || isDemoFallback
 
-  const { showSkeleton, showEmptyState } = useCardLoadingState()
+  const { showSkeleton, showEmptyState } = useCardLoadingState({ isLoading: dataLoading, isDemoData })
 
   // Transform every OpenKruise resource into a unified display item -----
   const allItems = useMemo<OpenKruiseDisplayItem[]>(() => {

--- a/web/src/components/cards/openyurt_status/index.tsx
+++ b/web/src/components/cards/openyurt_status/index.tsx
@@ -236,8 +236,6 @@ export function OpenYurtStatus({ config }: OpenYurtStatusProps = {}) {
     isRefreshing,
     isFailed,
     isDemoFallback,
-    consecutiveFailures,
-    lastRefresh,
   } = useOpenYurtStatus(cluster)
 
   const [search, setSearch] = useState('')
@@ -258,7 +256,7 @@ export function OpenYurtStatus({ config }: OpenYurtStatusProps = {}) {
     gateways.length > 0 ||
     controllerPods.total > 0
 
-  const { showSkeleton, showEmptyState } = useCardLoadingState()
+  const { showSkeleton, showEmptyState } = useCardLoadingState({ isLoading, hasAnyData, isFailed })
 
   const stats = {
     totalPools: nodePools.length,


### PR DESCRIPTION
## Security Fix

Resolves 17 open CodeQL `js/unused-local-variable` alerts across 6 files in the card components. These alerts were flagged in the GitHub Code Scanning dashboard.

### Changes

| File | Fix |
|------|-----|
| `CardDataContext.tsx` | Remove unused `isFailed` from `useCardLoadingState` body |
| `coredns_status/demoData.ts` | Remove unused `ONE_HOUR_MS` constant |
| `notary_status/index.tsx` | Wire `isDemoData` into `useCardLoadingState({ isDemoData })` |
| `kubeflow_status/index.tsx` | Remove unused `STATUS_ORDER`, `useClusters` import + `clustersLoading`; wire `isDemoData` |
| `openkruise_status/index.tsx` | Remove unused `STATUS_ORDER`, `useClusters` import + `clustersLoading`, `isRefreshing`, `isFailed`, `consecutiveFailures`, `lastRefresh`; wire `isLoading`+`isDemoData` |
| `openyurt_status/index.tsx` | Remove unused `consecutiveFailures`, `lastRefresh`; wire `isLoading`+`hasAnyData`+`isFailed` |

### Root Cause

Multiple card components called `useCardLoadingState()` with **no arguments**, meaning `showSkeleton` and `showEmptyState` always evaluated to `false`. Variables destructured from their data hooks (`isLoading`, `hasAnyData`, `isFailed`, etc.) were dead code. This PR wires the correct loading/demo state into each `useCardLoadingState` call, restoring the intended skeleton and empty-state UX.

---
*Filed by sec-check agent (ACMM L6 — full mode)*