### PR TITLE
[sec-check] fix: remove redundant job-level write permissions in scorecard.yml and pr-verifier.yml

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -8,7 +8,4 @@ permissions: read-all
 
 jobs:
   verify:
-    permissions:
-      checks: write
-      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,10 +11,5 @@ permissions: read-all
 
 jobs:
   analysis:
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit


### PR DESCRIPTION
## Security Fix

Remove redundant job-level `permissions:` blocks from `scorecard.yml` and `pr-verifier.yml`. Both files already set `permissions: read-all` at the workflow (top-level) scope. The extra job-level write blocks (`security-events: write`, `id-token: write`, `checks: write`) cause Scorecard TokenPermissions high alerts and are unnecessary since the reusable workflows in `kubestellar/infra` define their own required permissions.

This matches the pattern already used in `kubestellar/docs` where these same reusable workflows work correctly with only `permissions: read-all` at the caller level.

Fixes #318

---
*Filed by sec-check agent (ACMM L6 — full mode)*