### PR TITLE
[scanner] fix: document workflow permission requirements

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -21,8 +21,11 @@ jobs:
   ai-fix:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      # Required: Copilot agent needs to create commits and branches
       contents: write
+      # Required: Copilot agent assigns itself to issues and creates comments
       issues: write
+      # Required: Copilot agent creates pull requests to fix issues
       pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
     with:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -23,9 +23,13 @@ jobs:
   copilot-automation:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      # Required: reusable workflow creates and modifies commits (contents)
       contents: write
+      # Required: reusable workflow creates/updates PR reviews and comments
       pull-requests: write
+      # Required: reusable workflow creates and updates comments on issues
       issues: write
+      # Required: reusable workflow sets commit status checks
       statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
     with:

--- a/.github/workflows/marketplace-auto-qa.yml
+++ b/.github/workflows/marketplace-auto-qa.yml
@@ -31,10 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write      # Copilot needs write access to create branches
+      # Required: Copilot needs write access to create branches
+      contents: write
+      # Required: Auto-QA creates and updates issues for findings
       issues: write
-      pull-requests: write # Copilot needs to create PRs
-      actions: read        # Copilot needs to view workflow status
+      # Required: Copilot needs to create PRs to fix issues
+      pull-requests: write
+      # Required: Copilot needs to view workflow status
+      actions: read
     steps:
       - name: Checkout marketplace
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0


### PR DESCRIPTION
Fixes #321

Adds inline comments explaining why job-level write permissions are required for automation workflows:

- **copilot-automation.yml**: Needs write access to create commits, PR reviews, issue comments, and set status checks
- **ai-fix.yml**: Copilot agent requires write access to create commits, branches, and pull requests to fix issues  
- **marketplace-auto-qa.yml**: Auto-QA workflow needs write access to create issues and enable Copilot assignments

All write permissions follow the correct least-privilege pattern (read-all at workflow level, writes scoped to specific jobs) and are genuinely required for these automation workflows to function.