### PR TITLE
[scanner] fix: restrict write permissions on pull_request_target workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,10 +12,7 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: read
-  issues: read
-  pull-requests: read
+permissions: read-all
 
 jobs:
   ai-fix:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,10 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: read
-  issues: read
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/marketplace-auto-qa.yml
+++ b/.github/workflows/marketplace-auto-qa.yml
@@ -23,8 +23,7 @@ env:
   MAX_ISSUES_PER_RUN: 3
   ISSUE_PREFIX: "[Auto-QA]"
 
-permissions:
-  actions: read   # least-privilege top-level default (writes scoped to job below)
+permissions: read-all
 
 jobs:
   nightly-scan:


### PR DESCRIPTION
Fixes #325

Restricts write permissions on pull_request_target triggered workflows to prevent token abuse.