### PR TITLE
[scanner] fix: add fork guard and disable broken pr-verifier

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,9 @@ permissions:
 
 jobs:
   greet:
+    # Fork guard: restrict pull_request_target to same-repo PRs only.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -12,6 +12,5 @@ permissions:
 
 jobs:
   verify:
-    if: false
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,8 +1,10 @@
 name: PR Verifier
 
+# DISABLED: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml does not exist.
+# This workflow silently fails on every PR. Disabled until the reusable workflow is created.
+# See: https://github.com/kubestellar/console-marketplace/issues/335
 on:
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch: {}
 
 permissions:
   checks: write
@@ -10,5 +12,6 @@ permissions:
 
 jobs:
   verify:
+    if: false
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes #334
Fixes #335

- Adds fork guard to greetings.yml to prevent untrusted fork PRs from triggering with write access
- Disables pr-verifier.yml which calls a non-existent reusable workflow