### PR TITLE
[scanner] fix: Token-Permissions — move perms to job level in ai-fix.yml and copilot-automation.yml

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Fixes #339

Moves write permissions from workflow top-level to job-level in both `ai-fix.yml` and `copilot-automation.yml`, following OpenSSF Scorecard Token-Permissions best practice.