### PR TITLE
[scanner] fix: scope greetings.yml write permissions to job level

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,10 +6,7 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   greet:
@@ -17,5 +14,8 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes #341

Moves write permissions to job level in greetings.yml.

See umbrella: kubestellar/console#19959