### PR TITLE
[scanner] fix: harden workflow security

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,7 +23,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -26,7 +26,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -17,5 +17,5 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main
     secrets: inherit


### PR DESCRIPTION
Fixes #345

## Summary
Pin reusable workflows from kubestellar/infra to commit SHA instead of mutable @main reference.

## Changes
- Pin `reusable-ai-fix.yml` to commit SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`
- Pin `reusable-copilot-automation.yml` to commit SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`
- Pin `reusable-greetings.yml` to commit SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`

## Security Impact
This follows security best practices for GitHub Actions to prevent supply chain attacks by ensuring workflow definitions cannot be modified after being referenced.