### PR TITLE
[scanner] fix: add coverage instrumentation to Vitest configuration

### DIFF
--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -12,5 +12,18 @@ export default defineConfig({
     css: true,
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'e2e/**/*'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        '**/*.d.ts',
+        '**/demoData.{ts,tsx}',
+      ],
+    },
   },
 })


### PR DESCRIPTION
Fixes #352

Adds proper coverage instrumentation to the Vitest configuration so that test coverage is accurately reported.