### PR TITLE
[scanner] fix: add top-level permissions to pr-verifier.yml

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,11 +6,12 @@ name: PR Verifier
 on:
   workflow_dispatch: {}
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
Fixes #357

Adds explicit top-level `permissions: read-all` block to satisfy OpenSSF Scorecard TokenPermissions check. Scopes `checks: write` and `pull-requests: read` to the job level, following the principle of least privilege.