### PR TITLE
[ci-maintainer] fix: align codeql-action/analyze to v4.36.3 to fix CodeQL version skew

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## CI Fix

`CodeQL Analysis` has been failing on `main` since Dependabot PR #363 merged `codeql-action/init` to v4.36.3 while `analyze` remained at v4.36.2.

**Error:**
```
Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

**Root cause:** Dependabot opened separate PRs for `init` (#363, merged) and `analyze` (#364, open). PR #364's branch predates the merge of #363, so it has the *opposite* skew (init v4.36.2, analyze v4.36.3) — neither PR individually resolves main.

**Fix:** Bump `analyze` from SHA `8aad20d1...` (v4.36.2) to `54f647b7...` (v4.36.3), matching `init`.

Closes #365

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*