### PR TITLE
[scanner] fix: add required permissions to scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+  actions: read
 
 jobs:
   analysis:


### PR DESCRIPTION
Fixes #401

Adds `security-events: write` and `id-token: write` permissions needed by the Scorecard action. Also includes `actions: read` and restores explicit `contents: read` to replace the overly broad `permissions: read-all` that was blocking the workflow startup.