### PR TITLE
[scanner] fix: scope workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,7 +12,8 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   ai-fix:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,8 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   copilot-dco:


### PR DESCRIPTION
Fixes #408

## Summary

Scopes down overly broad `permissions: read-all` to minimum required permissions in 3 workflows, improving OpenSSF Scorecard Token-Permissions score.

### Workflows Updated

| Workflow | Before | After |
|----------|--------|-------|
| ai-fix.yml | `read-all` | `contents: read` |
| copilot-automation.yml | `read-all` | `contents: read` |
| copilot-dco.yml | `read-all` | `contents: read` |

Each workflow's jobs already declare their specific write permissions. The workflow-level permissions only need `contents: read` for basic checkout operations.