### PR TITLE
[scanner] fix: repair OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   analysis:
     permissions:
+      contents: read
       security-events: write
       id-token: write
+      actions: read
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08


### PR DESCRIPTION
Fixes #414

## CI Fix

Repairs the OpenSSF Scorecard workflow that was experiencing startup_failure.

---
*Filed by scanner agent*