### PR TITLE
ci: sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,16 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main as of 2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -18,13 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
-
 jobs:
   copilot-dco:
-    permissions:
-      contents: read
-      pull-requests: write
-      statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main as of 2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,6 +13,5 @@ permissions:
 
 jobs:
   greet:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main as of 2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
     secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,38 +5,10 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  contents: read
+  checks: write
+  pull-requests: read
 
 jobs:
-  verify-pr-title:
-    name: Verify PR Title
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: read
-      statuses: write
-    steps:
-      - name: Validate PR title (Conventional Commits)
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          # Allow optional [scanner], [agent], [ci-maintainer], [quality], [sec-check] prefix
-          # before the conventional commit type for automated PRs.
-          PATTERN='^(\[(scanner|agent|ci-maintainer|quality|sec-check)\] )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
-          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
-            echo "PR title is valid: $PR_TITLE"
-          else
-            echo "::error::PR title does not follow Conventional Commits format."
-            echo ""
-            echo "The PR title must follow Conventional Commits format."
-            echo "Automated PRs may use an optional prefix like [scanner] or [agent]."
-            echo ""
-            echo "Examples:"
-            echo "  fix: correct typo"
-            echo "  [scanner] fix: pin SHA"
-            echo "  feat(scope): add feature"
-            echo ""
-            echo "Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
-            exit 1
-          fi
+  verify:
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,16 +8,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
   security-events: write
-  id-token: write
+  contents: read
   actions: read
+  id-token: write
 
 jobs:
   analysis:
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
-      actions: read
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync