### PR TITLE
[scanner] fix: workflow permissions + pinned deps + PR Verifier

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install fuzzing dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install atheris jsonschema pytest
+          pip install atheris==2.3.0 jsonschema==4.23.0 pytest==8.3.4
 
       - name: Create fuzz target
         run: |

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,10 +5,50 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
+  contents: read
   checks: write
   pull-requests: read
 
 jobs:
   verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: read
+    steps:
+      - name: Check PR title format
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const validPrefixes = ['✨', '🐛', '📖', '📝', '⚠️', '🌱'];
+            const hasValidPrefix = validPrefixes.some(prefix => title.startsWith(prefix));
+            
+            if (!hasValidPrefix) {
+              core.setFailed(`PR title must start with one of: ${validPrefixes.join(', ')}`);
+            } else {
+              core.info('✓ PR title has valid emoji prefix');
+            }
+      
+      - name: Check DCO signoff
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            
+            const unsignedCommits = commits.data.filter(commit => {
+              const message = commit.commit.message;
+              return !message.includes('Signed-off-by:');
+            });
+            
+            if (unsignedCommits.length > 0) {
+              const commitList = unsignedCommits.map(c => `- ${c.sha.substring(0, 7)}: ${c.commit.message.split('\n')[0]}`).join('\n');
+              core.setFailed(`The following commits are missing DCO signoff:\n${commitList}\n\nPlease add signoff with: git commit --amend --signoff && git push --force`);
+            } else {
+              core.info('✓ All commits have DCO signoff');
+            }


### PR DESCRIPTION
Fixes #422
Fixes #423

## Changes

### Issue #422 - PR Verifier failing on Dependabot PRs
- Replaced non-existent reusable workflow with local implementation
- PR Verifier now checks title format and DCO signoff
- Works correctly on Dependabot PRs

### Issue #423 - Scorecard alerts
- Added `permissions: contents: read` to `copilot-dco.yml`
- Pinned pip dependencies in `fuzz.yml` to specific versions (atheris==2.3.0, jsonschema==4.23.0, pytest==8.3.4)
- Pinned `actions/github-script` to SHA in `pr-verifier.yml`