### PR TITLE
🌱 [scanner] chore(security): add explicit top-level permissions to workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,10 +11,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +19,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: read
 
 jobs:
   verify:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,12 +8,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
   actions: read
   id-token: write
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes #425

Resolves OpenSSF Scorecard Token-Permissions cluster by adding explicit top-level `permissions: contents: read` to all workflows and moving write-scoped permissions to individual jobs that require them.

Changes:
- `ai-fix.yml`: Added top-level `contents: read`, moved write scopes to job level
- `copilot-automation.yml`: Added top-level `contents: read`, moved write scopes to job level  
- `pr-verifier.yml`: Simplified top-level to `contents: read`, kept job-level permissions
- `scorecard.yml`: Moved `security-events: write` to job level, kept read scopes at top level