### PR TITLE
🐛 fix: update cncf-keda downloadUrl to resolve Auto-QA timeout warning

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -969,7 +969,7 @@
       "description": "KEDA autoscaler status, scaled object metrics, and trigger queue depths.",
       "author": "Community",
       "version": "0.0.1",
-      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/56de485a64b85316429ad5d82db018a12c1df2fd/presets/cncf-keda.json",
+      "downloadUrl": "https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-keda.json",
       "tags": [
         "cncf",
         "graduated",


### PR DESCRIPTION
Fixes #433

## Summary

The `cncf-keda` entry in `registry.json` had its `downloadUrl` pinned to commit `56de485a64b85316429ad5d82db018a12c1df2fd`, which does not contain `presets/cncf-keda.json`. This caused the Auto-QA download URL validation workflow to report:

> ⚠️ 'cncf-keda' URL unreachable: The read operation timed out

## Fix

Updated the `downloadUrl` to track the `main` branch, where `presets/cncf-keda.json` is present:

```
https://raw.githubusercontent.com/kubestellar/console-marketplace/main/presets/cncf-keda.json
```

## Related

- Issue #431 (validate-marketplace.py coverage for Results/parsers) is already addressed by PR #432.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>