### PR TITLE
🐛 fix: update registry.json updatedAt timestamp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "updatedAt": "2026-06-29T08:34:50Z",
+  "updatedAt": "2026-07-30T08:09:53Z",
   "items": [
     {
       "id": "sre-overview",


### PR DESCRIPTION
Fixes #437

Update the registry.json updatedAt field to the current date to resolve
the marketplace staleness warning. The previous timestamp was over 30 days
old, triggering the auto-QA check.

The registry freshness validation checks that updatedAt is within 30 days.
This commit refreshes the timestamp to clear the warning.